### PR TITLE
Avoid looping behaviour (maitland, yass ATDIS feeds)

### DIFF
--- a/lib/atdisplanningalertsfeed.rb
+++ b/lib/atdisplanningalertsfeed.rb
@@ -11,10 +11,15 @@ module ATDISPlanningAlertsFeed
     page = feed.applications(lodgement_date_start: options[:lodgement_date_start], lodgement_date_end: options[:lodgement_date_end])
 
     # Save the first page
-    save_page(page)
+    pages_processed = []
+    pages_processed << page.pagination.current if save_page(page)
 
     while page = page.next_page
-      save_page(page)
+      # Some ATDIS feeds incorrectly provide pagination
+      # and permit looping; so halt processing if we've already processed this page
+      break unless pages_processed.index(page.pagination.current).nil?
+
+      pages_processed << page.pagination.current if save_page(page)
     end
   end
 

--- a/lib/atdisplanningalertsfeed.rb
+++ b/lib/atdisplanningalertsfeed.rb
@@ -17,7 +17,10 @@ module ATDISPlanningAlertsFeed
     while page = page.next_page
       # Some ATDIS feeds incorrectly provide pagination
       # and permit looping; so halt processing if we've already processed this page
-      break unless pages_processed.index(page.pagination.current).nil?
+      unless pages_processed.index(page.pagination.current).nil?
+        puts "Page #{page.pagination.current} already processed; halting"
+        break
+      end
 
       pages_processed << page.pagination.current if save_page(page)
     end


### PR DESCRIPTION
Pagination is horrible with ATDIS feeds.

```
:~/maitland$ bundle exec ruby scraper.rb 
Saving page 1 of 7
Saving page 2 of 7
Saving page 3 of 7
Saving page 4 of 7
Saving page 5 of 7
Saving page 6 of 7
Saving page 6 of 7
Skipping already saved record DA-2016-0415
Skipping already saved record DA-2016-0414
Skipping already saved record DA-2016-0413
Skipping already saved record DA-2015-2525-B
Skipping already saved record DA-2016-0392
Skipping already saved record DA-2016-0394
Skipping already saved record DA-2016-0389
Skipping already saved record DA-2016-0388
Skipping already saved record DA-2016-0390
Skipping already saved record DA-2016-0373
Skipping already saved record DA-2016-0375
Skipping already saved record DA-2016-0384
Skipping already saved record DA-2016-0387
Skipping already saved record DA-2016-0386
Skipping already saved record DA-2016-0379
Skipping already saved record DA-2016-0383
Skipping already saved record DA-2016-0382
Skipping already saved record DA-2016-0363
Skipping already saved record DA-2016-0364
Skipping already saved record DA-2014-2945-A

Saving page 6 of 7
Skipping already saved record DA-2016-0415
Skipping already saved record DA-2016-0414
Skipping already saved record DA-2016-0413
Skipping already saved record DA-2015-2525-B
Skipping already saved record DA-2016-0392
Skipping already saved record DA-2016-0394
Skipping already saved record DA-2016-0389
Skipping already saved record DA-2016-0388
Skipping already saved record DA-2016-0390
Skipping already saved record DA-2016-0373
Skipping already saved record DA-2016-0375
Skipping already saved record DA-2016-0384
Skipping already saved record DA-2016-0387
Skipping already saved record DA-2016-0386
Skipping already saved record DA-2016-0379
Skipping already saved record DA-2016-0383
Skipping already saved record DA-2016-0382
Skipping already saved record DA-2016-0363
Skipping already saved record DA-2016-0364
Skipping already saved record DA-2014-2945-A
Saving page 6 of 7

```

This change breaks if we've already processed a particular page.  

```

Saving page 2 of 3
Skipping already saved record 005.2014.00000035.002
Skipping already saved record 005.2016.00000053.001
Skipping already saved record 005.2016.00000052.001
Skipping already saved record 005.2013.00000104.002
Skipping already saved record 005.2012.00000260.006
Skipping already saved record 005.2016.00000051.001
Skipping already saved record 005.2016.00000049.001
Skipping already saved record 005.2016.00000050.001
Skipping already saved record 005.2016.00000048.001
Skipping already saved record 005.2014.00000216.003
Skipping already saved record 005.2016.00000047.001
Skipping already saved record 005.2016.00000046.001
Skipping already saved record 005.2016.00000045.001
Skipping already saved record 005.2016.00000044.001
Skipping already saved record 005.2016.00000042.001
Skipping already saved record 005.2015.00000040.002
Skipping already saved record 005.2016.00000041.001
Skipping already saved record 005.2016.00000043.001
Skipping already saved record 005.2016.00000039.001
Skipping already saved record 005.2016.00000038.001

Page 2 already processed; halting
```
