### PR TITLE
Refactor feed for stability

### DIFF
--- a/atdisplanningalertsfeed.gemspec
+++ b/atdisplanningalertsfeed.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
 
   spec.add_runtime_dependency 'scraperwiki-morph'
   spec.add_runtime_dependency 'atdis'

--- a/lib/atdisplanningalertsfeed.rb
+++ b/lib/atdisplanningalertsfeed.rb
@@ -28,6 +28,7 @@ module ATDISPlanningAlertsFeed
       end
 
       pages_processed << page.pagination.current if save_page(page, logger)
+      logger.debug("Fetching #{page.next_url}")
     end
   end
 

--- a/lib/atdisplanningalertsfeed.rb
+++ b/lib/atdisplanningalertsfeed.rb
@@ -80,5 +80,7 @@ module ATDISPlanningAlertsFeed
         logger.info "Skipping already saved record " + record[:council_reference]
       end
     end
+
+    records
   end
 end

--- a/lib/atdisplanningalertsfeed.rb
+++ b/lib/atdisplanningalertsfeed.rb
@@ -6,28 +6,33 @@ require 'cgi'
 module ATDISPlanningAlertsFeed
   def self.save(url, options = {})
     feed = ATDIS::Feed.new(url)
+    logger = options[:logger]
+    logger ||= Logger.new(STDOUT)
+
     options[:lodgement_date_start] = (options[:lodgement_date_start] || Date.today - 30)
     options[:lodgement_date_end] = (options[:lodgement_date_end] || Date.today)
     page = feed.applications(lodgement_date_start: options[:lodgement_date_start], lodgement_date_end: options[:lodgement_date_end])
 
     # Save the first page
     pages_processed = []
-    pages_processed << page.pagination.current if save_page(page)
+    pages_processed << page.pagination.current if save_page(page, logger)
+
+    logger.debug("Fetching #{page.next_url}")
 
     while page = page.next_page
       # Some ATDIS feeds incorrectly provide pagination
       # and permit looping; so halt processing if we've already processed this page
       unless pages_processed.index(page.pagination.current).nil?
-        puts "Page #{page.pagination.current} already processed; halting"
+        logger.info("Page #{page.pagination.current} already processed; halting")
         break
       end
 
-      pages_processed << page.pagination.current if save_page(page)
+      pages_processed << page.pagination.current if save_page(page, logger)
     end
   end
 
-  def self.save_page(page)
-    puts "Saving page #{page.pagination.current} of #{page.pagination.pages}"
+  def self.save_page(page, logger)
+    logger.info("Saving page #{page.pagination.current} of #{page.pagination.pages}")
 
     page.response.each do |item|
       application = item.application

--- a/spec/atdis_planning_alerts_feed_spec.rb
+++ b/spec/atdis_planning_alerts_feed_spec.rb
@@ -25,13 +25,17 @@ describe ATDISPlanningAlertsFeed, :vcr do
     }
   end
   context 'valid feed' do
-    it 'should not error' do
-      ATDISPlanningAlertsFeed.save("http://mycouncil2.solorient.com.au/Horizon/@@horizondap_ashfield@@/atdis/1.0/")
+    it 'should not error on empty feed' do
+      records = ATDISPlanningAlertsFeed.save("http://mycouncil2.solorient.com.au/Horizon/@@horizondap_ashfield@@/atdis/1.0/")
+
+      expect(records.length).to eq 0
     end
   end
   context 'dodgy pagination' do
     it 'should not error' do
-      ATDISPlanningAlertsFeed.save("https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/")
+      records = ATDISPlanningAlertsFeed.save("https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/")
+
+      expect(records.length).to eq 120
     end
   end
 end

--- a/spec/atdis_planning_alerts_feed_spec.rb
+++ b/spec/atdis_planning_alerts_feed_spec.rb
@@ -1,0 +1,37 @@
+# TODO Shift to spec helper
+
+$: << "#{File.dirname(__FILE__)}/.."
+require 'atdisplanningalertsfeed'
+
+Bundler.require :development, :test
+
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.allow_http_connections_when_no_cassette = true
+  c.hook_into :webmock
+  c.default_cassette_options = { record: :new_episodes}
+  c.configure_rspec_metadata!
+end
+
+
+#
+describe ATDISPlanningAlertsFeed, :vcr do
+  before :each do
+    @options = {
+      lodgement_date_start: Date.parse("2016-02-21"),
+      lodgement_date_end: Date.parse("2016-03-22")
+    }
+  end
+  context 'valid feed' do
+    it 'should not error' do
+      ATDISPlanningAlertsFeed.save("http://mycouncil2.solorient.com.au/Horizon/@@horizondap_ashfield@@/atdis/1.0/")
+    end
+  end
+  context 'dodgy pagination' do
+    it 'should not error' do
+      ATDISPlanningAlertsFeed.save("https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/")
+    end
+  end
+end

--- a/spec/atdis_planning_alerts_feed_spec.rb
+++ b/spec/atdis_planning_alerts_feed_spec.rb
@@ -11,7 +11,7 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.allow_http_connections_when_no_cassette = true
   c.hook_into :webmock
-  c.default_cassette_options = { record: :new_episodes}
+  c.default_cassette_options = { record: :new_episodes }
   c.configure_rspec_metadata!
 end
 
@@ -26,16 +26,60 @@ describe ATDISPlanningAlertsFeed, :vcr do
   end
   context 'valid feed' do
     it 'should not error on empty feed' do
-      records = ATDISPlanningAlertsFeed.save("http://mycouncil2.solorient.com.au/Horizon/@@horizondap_ashfield@@/atdis/1.0/")
+      records = ATDISPlanningAlertsFeed.save("http://mycouncil2.solorient.com.au/Horizon/@@horizondap_ashfield@@/atdis/1.0/", @options)
 
       expect(records.length).to eq 0
     end
   end
   context 'dodgy pagination' do
     it 'should not error' do
-      records = ATDISPlanningAlertsFeed.save("https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/")
+      records = ATDISPlanningAlertsFeed.save("https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/", @options)
 
       expect(records.length).to eq 120
     end
+  end
+
+  context 'really dodgy pagination' do
+    it 'should not error' do
+      records = ATDISPlanningAlertsFeed.save("https://da.kiama.nsw.gov.au/atdis/1.0/", @options)
+
+      expect(records.length).to eq 43
+    end
+  end
+
+  context 'with a flakey service' do
+    # TODO This spec should always force a RestClient::InternalServerError: 500 Internal Server Error
+    it 'should not error' do
+      @options.merge!({
+        flakey: true
+      })
+      # TODO This doesn't work as expected (stackleveltoodeep), but the VCR cassette should work
+      # allow_any_instance_of(ATDIS::Feed).to receive(:applications).and_raise(RestClient::InternalServerError.new("500 Internal Server Error"))
+
+      url ="http://myhorizon.cootamundra.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/"
+      records = ATDISPlanningAlertsFeed.save(url, @options)
+
+      # TODO Expectation that a HTTP 500 on the first page recovers gracefully
+      expect(records.length).to eq 0
+    end
+
+    it 'should not error half way through processing' do
+      @options.merge!({
+        flakey: true
+      })
+
+      # TODO This doesn't work as expected
+      # But I have faked the response in the cassette
+      # allow_any_instance_of(ATDIS::Models::Page).to receive(:next_page).and_raise(RestClient::InternalServerError.new("500 Internal Server Error"))
+
+      # Yass isn't actually flakey, but Cootamundra is *too* flakey
+      # This scenario replicates one page of many having an unhandled exception (seen in Horizon DAP feeds)
+      url = "http://mycouncil.yass.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0/"
+      records = ATDISPlanningAlertsFeed.save(url, @options)
+
+      # TODO Expectation that a HTTP 500 on the second page still allows several errors to process
+      expect(records.length).to eq 20
+    end
+
   end
 end

--- a/spec/cassettes/ATDISPlanningAlertsFeed/dodgy_pagination/should_not_error.yml
+++ b/spec/cassettes/ATDISPlanningAlertsFeed/dodgy_pagination/should_not_error.yml
@@ -1,0 +1,3423 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:13:18 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=1C0795AA6CF1181E144CA4071777FEF0; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQhNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 1, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"LARGS\", \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"27 Hunter Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP1101097\", \r\n\"lot\": \"14\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.604000,
+        \r\n-32.704000]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Glenn Datson\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$19,760\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0589\", \r\n\"description\": \"Garage and Carport
+        and Demolition\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQgBMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 6, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"LORN\", \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"18 The Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP5394\", \r\n\"lot\": \"9\", \r\n\"section\": \"C\"}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.557000,
+        \r\n-32.731400]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Chris Morgan And Vivien Cox\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tegan Harris\", \r\n\"dat_id\": \"DA-2016-0608\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQgBAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 5, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"EAST MAITLAND\", \r\n\"postcode\": \"2323\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"83 Victoria Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP112872\", \r\n\"lot\": \"2\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.589000, \r\n-32.754700]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Manny Archibald And Annette Maher\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$100,000\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0604\", \r\n\"description\": \"Dwelling alteration\\/addition
+        (Cl 33)\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQgBEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 4, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"GILLIESTON HEIGHTS\", \r\n\"postcode\": \"2321\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"5 Holland Circuit\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1212970\", \r\n\"lot\": \"301\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Thomas Paul Constructions Pty Ltd\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$281,500\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0600\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQlDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 3, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"RUTHERFORD\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"41 Tournament Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP280047\", \r\n\"lot\": \"83\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Hudson Homes Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$220,858\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0597\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQlHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 2, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"MAITLAND\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"18 Wolfe Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP197396\", \r\n\"lot\": \"1\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.550000, \r\n-32.727600]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"LEE GALLOWAY\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tegan Harris\", \r\n\"dat_id\": \"DA-2016-0593\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQhMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 12, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"29 Heritage
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1206108\", \r\n\"lot\": \"1710\", \r\n\"section\": null}\r\n}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"CHISHOLM\", \r\n\"postcode\": \"2322\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"31 Heritage Drive\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1206108\", \r\n\"lot\": \"1711\",
+        \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Metricon Homes Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$395,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0588\", \r\n\"description\": \"Exhibition Home and
+        SIGN APPLICATION and Subdivision - boundary adjustment\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQhBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 10, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"243
+        Newcastle Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP7792\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.586000, \r\n-32.755700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Beiers
+        Investments Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"Pending\", \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0585\", \r\n\"description\": \"Change of Use\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQhCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 11, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"27 Hillcrest
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1205264\", \r\n\"lot\": \"856\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Aaron
+        Ryder\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$300,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0586\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQhHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 9, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"THORNTON\", \r\n\"postcode\": \"2322\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"8 Railway Avenue\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP838986\", \r\n\"lot\": \"142\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.642000, \r\n-32.783500]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Plan Vision\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$95,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0583\", \r\n\"description\": \"Dwelling alteration\\/addition
+        (Cl 33)\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQhGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 8, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"ASHTONFIELD\", \r\n\"postcode\": \"2323\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"2 Coromandel Close\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1213277\", \r\n\"lot\": \"3\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Mr Nathan Morante\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tegan Harris\", \r\n\"dat_id\": \"DA-2016-0582\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQdMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 7, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"BOLWARRA\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"44 Hunterglen Drive\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1186933\", \r\n\"lot\": \"2\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Troy Burton\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$10,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0578\", \r\n\"description\": \"Fence \\/ retaining
+        wall\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQdHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 20, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"15 Lang
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1216123\", \r\n\"lot\": \"4\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Dean Whitehorn
+        \ Anita Whitehorn\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"DEAN
+        WHITEHORN and ANITA WHITEHORN\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"MAITLAND CITY COUNCIL\", \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$77,929\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0573\", \r\n\"description\": \"Storage Shed\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQdEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 19, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"10 Pearse
+        Crescent\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1178446\", \r\n\"lot\": \"12\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"SMITH
+        BROTHERS HOMES T\\/A HOTONDO HOMES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"MADELINE KOUTSOUKOS\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"Madeline Katsoukos\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$298,851\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0570\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 14, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"OSWALD\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"172 Oswald Road\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP559586\",
+        \r\n\"lot\": \"107\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.415000, \r\n-32.696800]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Rachel Whiting\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"rural\",
+        \r\n\"notification_end_date\": \"11\\/04\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$80,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Alisa-Jane Evans\", \r\n\"dat_id\": \"DA-2016-0564\", \r\n\"description\":
+        \"Rural Tourist Accommodation and Animal Establishment\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\", \r\n\"notification_start_date\": \"28\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 13, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"Canna
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP585563\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.578000, \r\n-32.707100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Uniting Church in Australia\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": \"11\\/04\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$80,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0563\", \r\n\"description\": \"Place of Worship\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\", \r\n\"notification_start_date\":
+        \"28\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 18, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LARGS\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"6 Ash Close\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"SP76639\", \r\n\"lot\": \"2\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Richard Crickmore\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0569\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 17, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"161
+        Brunswick Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1004169\", \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.580000, \r\n-32.764500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MR PAUL
+        GOLDSMITH\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$19,810\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0568\", \r\n\"description\": \"Dwelling alteration\\/addition
+        (Cl 33)\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 16, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LOCHINVAR\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"60 New
+        England Highway\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1214402\", \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"LOCHINVAR\", \r\n\"postcode\": \"2321\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"56 New England Highway\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1214402\", \r\n\"lot\": \"1\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Anglican Parish Lochinvar\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"Ian Wilkinson (Signforce)\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$5,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2016-0567\", \r\n\"description\":
+        \"SIGN APPLICATION\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 15, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"13 Arrowgrass
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1176490\", \r\n\"lot\": \"3113\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Bartlett
+        Homes\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Bartlett Homes\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": \"11\\/04\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$725,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0566\", \r\n\"description\": \"Medium Density Housing\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\", \r\n\"notification_start_date\":
+        \"28\\/03\\/2016\"}\r\n}\r\n}\r\n] \r\n, \r\n\"count\": 20, \r\n\"pagination\":
+        {\r\n\"pages\": 7, \r\n\"per_page\": 20, \r\n\"next\": 2, \r\n\"count\": 133,
+        \r\n\"current\": 1}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:20:20 GMT
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:13:29 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=F4CE2858823CD81C5AF0664A2888B42A; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQdCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 22, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LOUTH PARK\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"24 Quiescent
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1096466\", \r\n\"lot\": \"809\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.556000, \r\n-32.778200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Mark Oldham
+        and Kim Oldham\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$19,890\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0576\", \r\n\"description\": \"Storage Shed\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQdBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 21, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"38 Tournament
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP280047\", \r\n\"lot\": \"89\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"CORAL
+        HOMES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Coral Homes c\\/-
+        Professional Planning Group\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"CORAL HOMES\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$21,973\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0575\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQVCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 24, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"9 Pinchtail
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1216020\", \r\n\"lot\": \"2106\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-16T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Eden Brae
+        Homes\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"EDEN BRAE HOMES\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$286,714\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-16T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0556\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 26, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Huntingdale
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1032401\", \r\n\"lot\": \"812\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.636000, \r\n-32.788300]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-16T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Rhomberg
+        Rail Australia\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Not
+        Specified\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"industrial\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$20,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-16T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tegan Harris\", \r\n\"dat_id\": \"DA-2016-0561\", \r\n\"description\":
+        \"Transport Depot\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQZEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 25, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"105
+        Brunswick Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP32226\", \r\n\"lot\": \"7\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.584000, \r\n-32.760100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-16T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Dianne
+        Hamer\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$23,640\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-16T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0560\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQVHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 23, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MORPETH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"52 High Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP714624\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.630000, \r\n-32.727300]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-16T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Vicki
+        Fraser\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-16T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Roxanne White\", \r\n\"dat_id\": \"DA-2016-0553\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQRNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 28, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"6 Coromandel
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1213277\", \r\n\"lot\": \"5\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Reece
+        Thompson\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-15T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Alisa-Jane Evans\", \r\n\"dat_id\": \"DA-2016-0549\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQRMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 27, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RAWORTH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"54A Raworth Avenue\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1204947\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\":
+        [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\": \"2016-03-15T00:00:00Z\",
+        \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"VALLEY HOMES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"Ms Lesa Hicks\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$384,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-15T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0548\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQVEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 29, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"10 Petrie
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP246016\", \r\n\"lot\": \"51\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.636000, \r\n-32.780500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Simon
+        James West\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$30,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-15T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0550\", \r\n\"description\": \"Dwelling alteration\\/addition
+        (Cl 33) and Pool and Garage\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQRFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 30, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"30 Vindin
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP21915\", \r\n\"lot\": \"1\", \r\n\"section\": \"C\"}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.531000, \r\n-32.717800]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Rhonda
+        Simmonette\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0541\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-15T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQRHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 32, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"10 Wallis
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP376271\", \r\n\"lot\": \"7\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.576000, \r\n-32.753900]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Macauley
+        Sales\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2016-0543\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-16T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQRGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 31, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"14 Mitchell
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1031540\", \r\n\"lot\": \"311\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.591000, \r\n-32.764500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n,\r\n{\r\n}\r\n] \r\n, \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Stockland Developments Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"commercial\", \r\n\"notification_end_date\": \"06\\/04\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$18,233,220\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Stephen Punch\", \r\n\"dat_id\": \"DA-2016-0542\", \r\n\"description\":
+        \"Entertainment Facility\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"23\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 33, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"TELARAH\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"38 McArthur Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP25641\", \r\n\"lot\":
+        \"83\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.529000, \r\n-32.723800]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"David
+        Taylor\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$45,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0527\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33) and Secondary Dwelling\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 34, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MORPETH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"40 Close Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1040245\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.631000, \r\n-32.726700]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Mark Sznicer\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0529\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-14T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQNFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 35, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"10 Prairie
+        Way\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1207978\",
+        \r\n\"lot\": \"908\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\":
+        [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\": \"2016-03-11T00:00:00Z\",
+        \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Hudson Homes Pty Ltd\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$277,860\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-11T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-14T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0531\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQNNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 36, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"DUCKENFIELD\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"883
+        Raymond Terrace Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP874894\", \r\n\"lot\": \"41\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.679000, \r\n-32.754600]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Walker
+        Home Improvements\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT
+        SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$18,424\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0539\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 38, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"14 Denton
+        Park Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1200195\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Signature
+        Gardens Retirement Resorts P\\/L C\\/- Valley Patios and Decks\", \r\n\"role\":
+        \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"SIGNATURE GARDENS RETIREMENT RESORTS P\\/L\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$11,290\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-10T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0520\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 39, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"21 Paradise
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1207978\", \r\n\"lot\": \"920\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Oracle Building Corporation\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$224,790\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-10T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0521\", \r\n\"description\":
+        \"Dwelling House and Fence \\/ retaining wall\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 40, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"405
+        Cessnock Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP663703\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.527000, \r\n-32.769300]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"GILLIESTON HEIGHTS\", \r\n\"postcode\": \"2321\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"391 Cessnock Road\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP377804\", \r\n\"lot\": \"0\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.527000, \r\n-32.768200]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-10T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n,\r\n{\r\n}\r\n]
+        \r\n, \r\n\"people\": [ \r\n{\r\n\"name\": \"Not Specified\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Maitland Property No1 Pty Ltd and Gillieston
+        Heights Investments Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\": \"04\\/04\\/2016\",
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"Pending\", \r\n\"lodgement_date\": \"2016-03-10T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Roxanne White\", \r\n\"dat_id\": \"DA-2016-0522\", \r\n\"description\":
+        \"Subdivision - New Road\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"21\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQFDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 37, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MAITLAND\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"64 Bulwer
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP150112\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.553000, \r\n-32.736700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Dean Parkinson\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"MAITLAND CITY COUNCIL\",
+        \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$10,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-10T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2016-0517\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"count\": 20, \r\n\"pagination\": {\r\n\"pages\": 7, \r\n\"per_page\":
+        20, \r\n\"next\": 3, \r\n\"previous\": 1, \r\n\"count\": 133, \r\n\"current\":
+        2}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:20:32 GMT
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:13:41 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=88806D41C314DC6076EE5F2A02693EB1; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 41, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"28 Waterworks
+        Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1192440\",
+        \r\n\"lot\": \"339\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\":
+        [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\": \"2016-03-10T00:00:00Z\",
+        \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Spanline Home Additions\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$16,000\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-18T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0524\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQJCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 42, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Daydream
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP262145\", \r\n\"lot\": \"213\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.600000, \r\n-32.772500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"N C Lindsley\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-10T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0526\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQBDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 45, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"TENAMBIT\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"49 Maize
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP755237\", \r\n\"lot\": \"278\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.603000, \r\n-32.745200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-09T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Donna Archer\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"other\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Alisa-Jane Evans\", \r\n\"dat_id\": \"DA-2016-0507\", \r\n\"description\":
+        \"Change of Use\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQBMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 46, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"11 Sandalyn
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1071247\", \r\n\"lot\": \"9617\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.654000, \r\n-32.774700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-09T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Guy Melmeth
+        c\\/- PatioWorld\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Not
+        Specified\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$14,500\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-09T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0508\", \r\n\"description\":
+        \"Carport\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RRQAhCbTZfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 43, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"28 Waterworks
+        Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1192440\",
+        \r\n\"lot\": \"339\", \r\n\"section\": null}\r\n}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"RUTHERFORD\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"Waterworks Road\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1192440\", \r\n\"lot\": \"338\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-09T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"MBK Holdings Pty Ltd C\\/- ACM Landmark\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$6,900,724\", \r\n\"status\": \"S96 Approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-09T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tegan Harris\", \r\n\"dat_id\": \"DA-2015-0486-B\", \r\n\"description\":
+        \"Medium Density Housing\", \r\n\"determination_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQBNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 47, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"4A Garnett
+        Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP816469\",
+        \r\n\"lot\": \"104\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.589000, \r\n-32.762100]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-09T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Daryl
+        Bailey\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-09T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Alisa-Jane Evans\", \r\n\"dat_id\": \"DA-2016-0509\", \r\n\"description\":
+        \"Change of Use\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQFHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 48, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"Firebrick
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1032401\", \r\n\"lot\": \"802\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.632000, \r\n-32.788200]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"THORNTON\", \r\n\"postcode\": \"2322\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"21 Firebrick Drive\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1103663\", \r\n\"lot\": \"101\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.631000, \r\n-32.787600]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-09T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Graham Burns\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"Not Specified\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$16,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-09T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Roxanne White\", \r\n\"dat_id\": \"DA-2016-0513\", \r\n\"description\":
+        \"Car Park\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQBBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 44, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"26 Daniel
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1173936\", \r\n\"lot\": \"4\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-09T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MAITLAND
+        CITY COUNCIL\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Edgar Campbell\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$11,665\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-09T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0505\", \r\n\"description\":
+        \"Shed\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCRVRTQABAbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 49, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"6 Kestrel
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP878202\", \r\n\"lot\": \"45\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.627000, \r\n-32.787100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-08T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Andrew
+        and Alana Redding\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"industrial\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$1,184,471\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-03-08T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2013-2404-A\", \r\n\"description\":
+        \"Industry \\/ Factory\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAlAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 50, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MORPETH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 Robert Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP519460\",
+        \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.629000, \r\n-32.728700]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-08T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Paul Hickey\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-08T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0494\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAlNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 51, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LORN\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"41 King Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP6373\", \r\n\"lot\":
+        \"3\", \r\n\"section\": \"4\"}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.562000, \r\n-32.728200]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"LORN\", \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"41 King Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP6373\", \r\n\"lot\": \"2\", \r\n\"section\": \"4\"}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.562000,
+        \r\n-32.728100]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-08T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"L SHARPE\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-08T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0499\", \r\n\"description\":
+        \"Subdivision - boundary adjustment\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQBFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 52, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"31 Maher
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP245075\", \r\n\"lot\": \"23\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.579000, \r\n-32.760500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-08T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Stephen
+        Slater\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-08T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0501\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQQBGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 53, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"25 Mitchell
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP270403\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.587000, \r\n-32.762800]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-08T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Aaron
+        Abela\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-08T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0502\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-09T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAhEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 54, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"15 Rusden
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP238205\", \r\n\"lot\": \"17\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.582000, \r\n-32.764700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"John Hughes
+        \ Kay Hughes\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0480\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-09T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAhFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 55, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"11 Silky
+        Oak Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP841522\", \r\n\"lot\": \"226\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.522000, \r\n-32.698000]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Matthew
+        Peters and Johanna Peters\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$45,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0481\", \r\n\"description\":
+        \"Storage Shed\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAhHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 56, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"29 Government
+        Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP28011\",
+        \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.641000, \r\n-32.780900]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"David
+        Pegler\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$19,475\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0483\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAhBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 57, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"68 Burg
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP37382\", \r\n\"lot\": \"10\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.585000, \r\n-32.756600]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Jeff Robinson\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$13,900\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-08T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0485\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAhDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 58, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MAITLAND\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"44 Ward
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP157312\", \r\n\"lot\": \"0\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.560000, \r\n-32.742200]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"MAITLAND\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"44 Ward Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP157312\", \r\n\"lot\": \"0\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.560000, \r\n-32.742100]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Jeff Robinson\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$19,900\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Alisa-Jane Evans\", \r\n\"dat_id\": \"DA-2016-0487\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAhNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 59, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"85 South
+        Seas Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP834767\", \r\n\"lot\": \"27\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.596000, \r\n-32.773000]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Craig
+        Fisher\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$15,500\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0489\", \r\n\"description\":
+        \"Storage Shed\", \r\n\"determination_date\": \"2016-03-15T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAlFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 60, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"23 Sapphire
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1197857\", \r\n\"lot\": \"54\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Tecara
+        Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Roxanne White\", \r\n\"dat_id\": \"DA-2016-0491\", \r\n\"description\":
+        \"Subdivision - No New Roads\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n] \r\n, \r\n\"count\": 20, \r\n\"pagination\": {\r\n\"pages\":
+        7, \r\n\"per_page\": 20, \r\n\"next\": 4, \r\n\"previous\": 2, \r\n\"count\":
+        133, \r\n\"current\": 3}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:20:44 GMT
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:13:52 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=2F2E38D51A1D66059BA1E2B562AA1A65; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQAlHbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 62, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"10 Flatwing
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1209575\", \r\n\"lot\": \"1813\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ELK DESIGNS\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$277,910\", \r\n\"status\": \"S96 Approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2015-2493-A\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": \"2016-03-16T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQgdCbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 63, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"18A
+        Horizon Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1205264\", \r\n\"lot\": \"811\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ELK DESIGNS\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"ELK DESIGN\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$223,500\", \r\n\"status\": \"S96 Approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2015-2676-A\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": \"2016-03-17T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQgdDbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 64, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"7 Horizon
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1205264\", \r\n\"lot\": \"827\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ELK DESIGNS\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$233,500\", \r\n\"status\": \"S96 Approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2015-2677-A\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": \"2016-03-17T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAlGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 61, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"129
+        Brunswick Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP222302\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.582000, \r\n-32.761600]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-07T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n] \r\n, \r\n\"people\": [ \r\n{\r\n\"name\":
+        \"BIHUA TAN\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Tan Bihua\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"commercial\", \r\n\"notification_end_date\": \"30\\/03\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-07T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2016-0492\", \r\n\"description\":
+        \"Home Activity\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"16\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAdNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 70, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"51 Heritage
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1210562\", \r\n\"lot\": \"1919\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-04T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Coral
+        Homes C\\/- Complete Planning Solutions\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"CORAL HOMES\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT
+        SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$357,375\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-04T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0479\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-16T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAdCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 68, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"19 Vantage
+        Court\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1213455\", \r\n\"lot\": \"111\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-04T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Eden Brae
+        Homes\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$319,656\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-04T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0476\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAdBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 67, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"8 Arrowtail
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1183001\", \r\n\"lot\": \"654\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-04T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ALAN MCNAB\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\":
+        \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$8,500\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-04T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0475\", \r\n\"description\":
+        \"Carport\", \r\n\"determination_date\": \"2016-03-15T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAdDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 69, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"43 Tournament
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP280047\", \r\n\"lot\": \"84\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-04T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Perry
+        Homes (Aust) Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$261,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-08T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0477\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAdAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 66, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"23 Verdant
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP247251\", \r\n\"lot\": \"66\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.593000, \r\n-32.767700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-04T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Brett
+        Payne\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-04T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0474\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAdHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 65, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 Weakleys
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1214688\", \r\n\"lot\": \"111\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-04T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"GWH Build
+        Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"GWH BUILD
+        PTY LTD\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-04T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Roxanne White\", \r\n\"dat_id\": \"DA-2016-0473\", \r\n\"description\":
+        \"SIGN APPLICATION\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAZMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 74, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"79 Brunswick
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP369218\", \r\n\"lot\": \"0\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.587000, \r\n-32.758500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-03T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \" Craig
+        Sutton\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"CRAIG SUTTON\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\":
+        \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$70,000\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0468\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAZNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 75, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"4 Blackett
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP243010\", \r\n\"lot\": \"49\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.584000, \r\n-32.764000]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-03T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NICHOLAS
+        WIGGINS\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-03T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0469\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAZCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 73, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Crestview
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1175140\", \r\n\"lot\": \"718\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-03T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"BEECHWOOD
+        HOMES - NORTH COAST\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"REGAN
+        WOOLLARD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$242,702\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-03T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0466\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTRQNHbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 76, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"41 Seasons
+        Circuit\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1194158\", \r\n\"lot\": \"168\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-03T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"PHILIP
+        COSGROVE\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$300,000\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-03T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2015-2133-A\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAZBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 72, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"METFORD\", \r\n\"postcode\":
+        \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"19 Stafford Close\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP240405\",
+        \r\n\"lot\": \"8\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.599000, \r\n-32.764900]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-03T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"GRAHAM
+        UPTON\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-03T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0465\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAZHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 71, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"WINDELLA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"13 Orlando
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1195506\", \r\n\"lot\": \"312\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-03T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"REBECCA
+        HARTCHER and STEVEN HARTCHER\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"Rebecca Hartcher and Steven Hartcher\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$353,770\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0463\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-10T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQARHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 78, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"150B
+        Bolwarra Park Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1185346\", \r\n\"lot\": \"216\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MICHAEL
+        JOHNSON\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$2,400\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0443\", \r\n\"description\":
+        \"Fence \\/ retaining wall\", \r\n\"determination_date\": \"2016-03-08T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQARCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 80, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"METFORD\", \r\n\"postcode\":
+        \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Moran Close\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP703547\",
+        \r\n\"lot\": \"631\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.613000, \r\n-32.773200]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"R C COTTIER\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0446\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQARBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 79, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MAITLAND\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1A Johnson
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP848614\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.542000, \r\n-32.726300]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"ALBERT SMITH SIGNS PTY
+        LTD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$43,705\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Alisa-Jane Evans\", \r\n\"dat_id\": \"DA-2016-0445\", \r\n\"description\":
+        \"SIGN APPLICATION\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQANNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 77, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LOCHINVAR\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"13 Loch
+        Katrine Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1122901\", \r\n\"lot\": \"114\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.437000, \r\n-32.699200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"HANNAH
+        RICHARDSON and SAM BAILLIE\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$500,000\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-11T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0439\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n] \r\n, \r\n\"count\": 20, \r\n\"pagination\": {\r\n\"pages\":
+        7, \r\n\"per_page\": 20, \r\n\"next\": 5, \r\n\"previous\": 3, \r\n\"count\":
+        133, \r\n\"current\": 4}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:20:54 GMT
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:14:05 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=5E9805A0AC3574CD31DB560456604E16; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAVHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 84, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"30 Arthur
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP21143\", \r\n\"lot\": \"16\", \r\n\"section\": \"4\"}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.524000, \r\n-32.720100]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"RUTHERFORD\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"30 Arthur Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP21143\", \r\n\"lot\": \"15\", \r\n\"section\":
+        \"4\"}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.524000, \r\n-32.720100]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"HUNTER HOMES SERVICES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"FRED FREEMAN\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$15,200\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2016-0453\", \r\n\"description\": \"Carport\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQARMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 82, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"15 Pinnacle
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1069088\", \r\n\"lot\": \"610\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.593000, \r\n-32.701400]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"TOM CAV\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"ARLEY BOUDAN\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"other\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$80,000\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0448\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33) and Shed\", \r\n\"determination_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQARDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 81, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LORN\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"4 Wood Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP578362\",
+        \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.556000, \r\n-32.725700]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"R.J. SCOBIE\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0447\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAVEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 83, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"FARLEY\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"26 Owlpen Lane\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP301517\",
+        \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.515000, \r\n-32.733100]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"GARY JOHN
+        CANT and MARGARET ANN CANT\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$24,950\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0450\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQwRBbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 85, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"42 Portabello
+        Crescent\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1210092\", \r\n\"lot\": \"412\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-02T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"WILLIAMS
+        DESIGNER HOMES PTY LTD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$376,618\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-03-02T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2015-2745-A\", \r\n\"description\": \"Dwelling House\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAJMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 88, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"Waterworks
+        Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1192440\",
+        \r\n\"lot\": \"338\", \r\n\"section\": null}\r\n}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"RUTHERFORD\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"28 Waterworks Road\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1192440\", \r\n\"lot\": \"339\", \r\n\"section\":
+        null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No
+        Events\", \r\n\"timestamp\": \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"WG INVESTCORP PTY LTD\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"WG
+        Investcope Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$14,380\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-03-01T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0428\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": \"2016-03-09T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAJDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 87, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"24 Denton
+        Park Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"SP43466\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"BARBARA MEISTER\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$26,220\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-01T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0427\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAJCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 86, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"16 Amber
+        Grove\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1040637\", \r\n\"lot\": \"50\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.579000, \r\n-32.700600]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Not Specified\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"COMPLETE PLANNING SOLUTIONS\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$22,864\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-01T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0426\", \r\n\"description\":
+        \"Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQANCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 91, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Hermitage
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP874539\", \r\n\"lot\": \"9113\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.648000, \r\n-32.775600]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"STEPHEN LESLIE GORTON\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$24,780\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-01T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0436\", \r\n\"description\":
+        \"Garage\", \r\n\"determination_date\": \"2016-03-17T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQANDbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 92, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Hermitage
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP874539\", \r\n\"lot\": \"9113\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.648000, \r\n-32.775600]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"STEPHEN
+        GORTON\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-03-01T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0437\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQANGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 90, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"CHISHOLM\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"59 McFarlanes
+        Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1144068\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.654000, \r\n-32.760900]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"CHISHOLM\", \r\n\"postcode\": \"2322\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"Raymond Terrace Road\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP797020\", \r\n\"lot\": \"2\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [151.652000, \r\n-32.763500]}\r\n}\r\n,\r\n{\r\n\"address\": {\r\n\"suburb\":
+        \"CHISHOLM\", \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\":
+        \"39 McFarlanes Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP797020\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.655000, \r\n-32.762500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n,\r\n{\r\n}\r\n] \r\n, \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Not Specified\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"ALLAM PROPERTY GROUP\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\": \"12\\/04\\/2016\",
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"Pending\", \r\n\"lodgement_date\": \"2016-03-01T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Robyn Hawes\", \r\n\"dat_id\": \"DA-2016-0432\", \r\n\"description\":
+        \"Subdivision - New Road\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"14\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQANFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 89, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Holland
+        Circuit\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1212970\", \r\n\"lot\": \"316\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-03-01T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Michael Robert Vicary
+        and Susan Debra Vicary\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"M R and S D VICARY C\\/- CHRIS DORAN  POWER OF ATTORNEY\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$460,000\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-03-01T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-10T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0431\", \r\n\"description\":
+        \"Dual Occupancy \\/ Duplex and Subdivision - No New Roads and Fence \\/ retaining
+        wall\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTTAJEbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 98, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"165
+        Paterson Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP771937\", \r\n\"lot\": \"251\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.581000, \r\n-32.705500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-29T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ALAN CAMERON
+        ARCHER and JEAN ISABELLA ARCHER\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$49,900\",
+        \r\n\"status\": \"S96 Approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-29T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"dat_id\": \"DA-2015-2820-A\", \r\n\"description\": \"Dwelling alteration\\/addition
+        (Cl 33)\", \r\n\"determination_date\": \"2016-03-10T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 93, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"29 Harrop
+        Parade\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1209054\", \r\n\"lot\": \"259\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-29T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"BAXTER
+        BUILDING\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"LAURIE and
+        SARAH ILJAZOV\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$290,629\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-29T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0418\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAJAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 97, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"149
+        Aberglasslyn Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP577474\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.540000, \r\n-32.707000]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-29T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n,\r\n{\r\n}\r\n] \r\n, \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"HUNTER VALLEY SOLUTIONS PTY LTD.\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\":
+        \"23\\/03\\/2016\", \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\":
+        \"$0\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-02-29T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Robyn Hawes\", \r\n\"dat_id\": \"DA-2016-0424\", \r\n\"description\":
+        \"Subdivision - No New Roads\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"09\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAJHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 96, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 George
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP758374\", \r\n\"lot\": \"18\", \r\n\"section\": \"30\"}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.597000, \r\n-32.746100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-29T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"SHANE
+        WALTON\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-29T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-02T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0423\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-02T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 94, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"33 Paradise
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1205264\", \r\n\"lot\": \"840\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-29T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"SURYA
+        PINGALA and NAGA KONDEPUDI\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"ALLWORTH CONSTRUCTIONS\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"Surya Pingala and Maga Kondepudi\", \r\n\"role\": \"Applicant\"}\r\n] \r\n,
+        \r\n\"info\": {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$214,210\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-29T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0419\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-15T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAJFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 95, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LOUTH PARK\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"31 Tranquil
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1060185\", \r\n\"lot\": \"720\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.556000, \r\n-32.777100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-29T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"HUNTER
+        VALLEY HOMES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"CKT DEVELOPMENTS
+        PTY LTD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$130,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-29T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0421\", \r\n\"description\":
+        \"Dual Occupancy \\/ Duplex and Manufactured Home\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCRFRSQglNbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 99, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"Vista
+        Parade\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1100309\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.574000, \r\n-32.761400]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"EAST MAITLAND\", \r\n\"postcode\": \"2323\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"Mingay Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP616027\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.575000,
+        \r\n-32.761800]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n]
+        \r\n, \r\n\"people\": [ \r\n{\r\n\"name\": \"PULVER COOPER and BLACKLEY\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": \"23\\/03\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Council\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-04T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tegan Harris\", \r\n\"dat_id\": \"DA-2012-3699-A\", \r\n\"description\":
+        \"Subdivision - New Road\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"09\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQgBMbTVfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 100, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MINDARIBBA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"451
+        Tocal Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1204924\", \r\n\"lot\": \"5\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"HELEN
+        STRONACH ARCHITECTS PTY LTD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$1,800,000\",
+        \r\n\"status\": \"S96 Approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2015-2608-A\", \r\n\"description\":
+        \"Dwelling House and Garage and Pool\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n] \r\n, \r\n\"count\": 20,
+        \r\n\"pagination\": {\r\n\"pages\": 7, \r\n\"per_page\": 20, \r\n\"next\":
+        6, \r\n\"previous\": 4, \r\n\"count\": 133, \r\n\"current\": 5}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:21:07 GMT
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:14:17 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=CC8ACA2EDDF84B7C2A6AE1C415D31592; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQABMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 104, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"24 Cockatoo
+        Ridge\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1169721\", \r\n\"lot\": \"2801\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"KYLE WINTERBURN\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$357,330\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0408\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 102, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"13 Glenlee
+        Court\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP883482\", \r\n\"lot\": \"9305\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.650000, \r\n-32.773800]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"TIMOTHY
+        CRAWFORD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$32,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-02T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0396\", \r\n\"description\":
+        \"Shed\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQABCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 103, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"17 Vantage
+        Court\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1213455\", \r\n\"lot\": \"110\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n] \r\n, \r\n\"people\": [ \r\n{\r\n\"name\":
+        \"JEFFREY and TINA NEWSTEAD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": \"16\\/03\\/2016\",
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$31,944\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0406\", \r\n\"description\":
+        \"Shed\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\",
+        \r\n\"notification_start_date\": \"08\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 109, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"38 Finch
+        Crescent\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1182710\", \r\n\"lot\": \"3617\", \r\n\"section\": null}\r\n}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"ABERGLASSLYN\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"45 Finch Crescent\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1182710\", \r\n\"lot\": \"3619\",
+        \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"CORAL HOMES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"CORAL HOMES\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$278,779\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0415\", \r\n\"description\":
+        \"Dwelling House and Fence \\/ retaining wall\", \r\n\"determination_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 106, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MORPETH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 Palmer Lane\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP280039\",
+        \r\n\"lot\": \"4\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\":
+        [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\": \"2016-02-26T00:00:00Z\",
+        \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"JAMES FREDSALL\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"unknown\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\":
+        \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0412\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 105, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"200
+        Paterson Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP23081\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.583000, \r\n-32.702700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n,\r\n{\r\n}\r\n] \r\n, \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"COMPLETE PLANNING SOLUTIONS\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"commercial\", \r\n\"notification_end_date\": \"23\\/03\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$1,633,373\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Robyn Hawes\", \r\n\"dat_id\": \"DA-2016-0411\", \r\n\"description\":
+        \"Demolition and Service Station\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"09\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 108, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Quince
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1208146\", \r\n\"lot\": \"513\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"CORAL
+        HOMES\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"CORAL HOMES\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$215,000\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0414\", \r\n\"description\":
+        \"Dwelling House and Fence \\/ retaining wall\", \r\n\"determination_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 107, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Wilton
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP855275\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.573000, \r\n-32.770100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NEEPA
+        VAKIL\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0413\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 101, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Ashmore
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1121294\", \r\n\"lot\": \"70\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MURPHY
+        BUILDERS QLD PTY LTD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0395\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQQJBbTZfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 110, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GRETA\", \r\n\"postcode\":
+        \"2334\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Valentine Close\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP883618\",
+        \r\n\"lot\": \"5\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.400000, \r\n-32.679700]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Anthony
+        Filipuzzi\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"ANTHONY
+        and BELLINDA FILIPUZZI\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$55,000\",
+        \r\n\"status\": \"S96 Approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2015-2525-B\", \r\n\"description\":
+        \"Secondary Dwelling\", \r\n\"determination_date\": \"2016-03-09T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 114, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RAWORTH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"12 Lantry Close\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP773323\",
+        \r\n\"lot\": \"92\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.615000, \r\n-32.730400]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MR QUINN\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$17,839\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0392\", \r\n\"description\":
+        \"Shed and Carport\", \r\n\"determination_date\": \"2016-03-14T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 115, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Moriarty
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1011483\", \r\n\"lot\": \"827\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.590000, \r\n-32.774800]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"R SPITTLES\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\":
+        \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$72,800\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-01T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0394\", \r\n\"description\":
+        \"Shed and Pool and Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 112, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Quince
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1208146\", \r\n\"lot\": \"525\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ELK DESIGNS\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\":
+        \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$296,504\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0389\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 111, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"136
+        Lawes Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP615660\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.590000, \r\n-32.753100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"PHILLIP R NORRIE\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$4,000\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0388\", \r\n\"description\":
+        \"Demolition\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 113, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1B Hartley
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP270393\", \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.635000, \r\n-32.791500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"BEAUTY
+        THERAPY COLLEGE OF AUSTRALIA\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$400,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2016-0390\", \r\n\"description\":
+        \"Change of Use\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwdHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 116, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"22 John
+        Verge Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1051221\", \r\n\"lot\": \"422\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.534000, \r\n-32.711200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"CALLAN
+        and TERREY WILSON\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$17,900\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0373\", \r\n\"description\":
+        \"Storage Shed\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwdBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 117, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"59 Bonville
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1053442\", \r\n\"lot\": \"9112\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.632000, \r\n-32.784200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ALLGAL\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"STRATEGIC SERVICES AUSTRALIA\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$25,620\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0375\", \r\n\"description\":
+        \"Carport\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwdNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 118, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"25 Grand
+        Parade\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP280047\", \r\n\"lot\": \"77\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ABDULLAH
+        ANWARI\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$351,485\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-04T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0379\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 120, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 Lavender
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1194709\", \r\n\"lot\": \"132\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ORACLE
+        BUILDING CORPORATION\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$342,050\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0383\", \r\n\"description\":
+        \"Dual Occupancy \\/ Duplex\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 119, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LORN\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Leslie Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP6373\", \r\n\"lot\":
+        \"15\", \r\n\"section\": \"7\"}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.562000, \r\n-32.729900]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Mark and
+        Kellie Lantry\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"MARK
+        and KELLIE LANTRY\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-02-29T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0382\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-02-29T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n] \r\n, \r\n\"count\": 20,
+        \r\n\"pagination\": {\r\n\"pages\": 7, \r\n\"per_page\": 20, \r\n\"next\":
+        7, \r\n\"previous\": 5, \r\n\"count\": 133, \r\n\"current\": 6}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:21:19 GMT
+- request:
+    method: get
+    uri: https://myhorizon.maitland.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.8.0
+      Date:
+      - Tue, 22 Mar 2016 04:14:28 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      Expires:
+      - Thu, 01 Jan 1970 10:00:00 AEST
+      Set-Cookie:
+      - JSESSIONID=5F8B31DBD87CC9419D629022EA720433; Path=/Horizon/; Secure; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQABMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 104, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"24 Cockatoo
+        Ridge\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1169721\", \r\n\"lot\": \"2801\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"KYLE WINTERBURN\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$357,330\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0408\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 102, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"13 Glenlee
+        Court\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP883482\", \r\n\"lot\": \"9305\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.650000, \r\n-32.773800]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"TIMOTHY
+        CRAWFORD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$32,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-02T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0396\", \r\n\"description\":
+        \"Shed\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQABCbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 103, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"17 Vantage
+        Court\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1213455\", \r\n\"lot\": \"110\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n] \r\n, \r\n\"people\": [ \r\n{\r\n\"name\":
+        \"JEFFREY and TINA NEWSTEAD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": \"16\\/03\\/2016\",
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$31,944\",
+        \r\n\"status\": \"Pending\", \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0406\", \r\n\"description\":
+        \"Shed\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\",
+        \r\n\"notification_start_date\": \"08\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 109, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ABERGLASSLYN\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"38 Finch
+        Crescent\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1182710\", \r\n\"lot\": \"3617\", \r\n\"section\": null}\r\n}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"ABERGLASSLYN\", \r\n\"postcode\": \"2320\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"45 Finch Crescent\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1182710\", \r\n\"lot\": \"3619\",
+        \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"CORAL HOMES\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"CORAL HOMES\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$278,779\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0415\", \r\n\"description\":
+        \"Dwelling House and Fence \\/ retaining wall\", \r\n\"determination_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 106, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MORPETH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 Palmer Lane\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP280039\",
+        \r\n\"lot\": \"4\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n, \r\n\"events\":
+        [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\": \"2016-02-26T00:00:00Z\",
+        \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"JAMES FREDSALL\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"unknown\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\":
+        \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0412\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFFbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 105, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOLWARRA HEIGHTS\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"200
+        Paterson Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP23081\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.583000, \r\n-32.702700]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [ \r\n{\r\n}\r\n,\r\n{\r\n}\r\n] \r\n, \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"COMPLETE PLANNING SOLUTIONS\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"commercial\", \r\n\"notification_end_date\": \"23\\/03\\/2016\", \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$1,633,373\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-09T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Robyn Hawes\", \r\n\"dat_id\": \"DA-2016-0411\", \r\n\"description\":
+        \"Demolition and Service Station\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\", \r\n\"notification_start_date\": \"09\\/03\\/2016\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 108, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Quince
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1208146\", \r\n\"lot\": \"513\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"CORAL
+        HOMES\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"CORAL HOMES\",
+        \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$215,000\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0414\", \r\n\"description\":
+        \"Dwelling House and Fence \\/ retaining wall\", \r\n\"determination_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRQAFHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 107, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Wilton
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP855275\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.573000, \r\n-32.770100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NEEPA
+        VAKIL\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"unknown\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-03T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0413\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-03T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 101, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Ashmore
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1121294\", \r\n\"lot\": \"70\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-26T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MURPHY
+        BUILDERS QLD PTY LTD\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-26T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0395\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-03-07T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQ1RTQQJBbTZfGhNHLAIYAw%3D%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 110, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GRETA\", \r\n\"postcode\":
+        \"2334\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 Valentine Close\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP883618\",
+        \r\n\"lot\": \"5\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.400000, \r\n-32.679700]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Anthony
+        Filipuzzi\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"ANTHONY
+        and BELLINDA FILIPUZZI\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"residential\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$55,000\",
+        \r\n\"status\": \"S96 Approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2015-2525-B\", \r\n\"description\":
+        \"Secondary Dwelling\", \r\n\"determination_date\": \"2016-03-09T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 114, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RAWORTH\", \r\n\"postcode\":
+        \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"12 Lantry Close\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP773323\",
+        \r\n\"lot\": \"92\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.615000, \r\n-32.730400]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"MR QUINN\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$17,839\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-17T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Tom Wroblewski\", \r\n\"dat_id\": \"DA-2016-0392\", \r\n\"description\":
+        \"Shed and Carport\", \r\n\"determination_date\": \"2016-03-14T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlAbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 115, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"ASHTONFIELD\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Moriarty
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1011483\", \r\n\"lot\": \"827\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.590000, \r\n-32.774800]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"R SPITTLES\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\":
+        \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$72,800\", \r\n\"status\": \"Pending\", \r\n\"lodgement_date\":
+        \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-01T00:00:00Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Maitland City Council\", \r\n\"ref\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Colin Garlick\", \r\n\"dat_id\": \"DA-2016-0394\", \r\n\"description\":
+        \"Shed and Pool and Dwelling alteration\\/addition (Cl 33)\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 112, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Quince
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1208146\", \r\n\"lot\": \"525\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ELK DESIGNS\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"NOT SPECIFIED\", \r\n\"role\":
+        \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$296,504\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Gavan Leary\", \r\n\"dat_id\": \"DA-2016-0389\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhMbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 111, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"EAST MAITLAND\",
+        \r\n\"postcode\": \"2323\", \r\n\"state\": \"NSW\", \r\n\"street\": \"136
+        Lawes Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP615660\", \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.590000, \r\n-32.753100]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"NOT SPECIFIED\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"PHILLIP R NORRIE\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"residential\",
+        \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$4,000\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0388\", \r\n\"description\":
+        \"Demolition\", \r\n\"determination_date\": \"2016-03-11T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwlEbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 113, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1B Hartley
+        Drive\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP270393\", \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.635000, \r\n-32.791500]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-25T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"BEAUTY
+        THERAPY COLLEGE OF AUSTRALIA\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$400,000\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-25T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Amanda Wells\", \r\n\"dat_id\": \"DA-2016-0390\", \r\n\"description\":
+        \"Change of Use\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwdHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 116, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"22 John
+        Verge Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1051221\", \r\n\"lot\": \"422\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.534000, \r\n-32.711200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"CALLAN
+        and TERREY WILSON\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"other\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$17,900\",
+        \r\n\"status\": \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0373\", \r\n\"description\":
+        \"Storage Shed\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwdBbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 117, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"THORNTON\",
+        \r\n\"postcode\": \"2322\", \r\n\"state\": \"NSW\", \r\n\"street\": \"59 Bonville
+        Avenue\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1053442\", \r\n\"lot\": \"9112\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [151.632000, \r\n-32.784200]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ALLGAL\",
+        \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"STRATEGIC SERVICES AUSTRALIA\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$25,620\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-07T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0375\", \r\n\"description\":
+        \"Carport\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwdNbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 118, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"RUTHERFORD\",
+        \r\n\"postcode\": \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"25 Grand
+        Parade\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP280047\", \r\n\"lot\": \"77\", \r\n\"section\": null}\r\n}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ABDULLAH
+        ANWARI\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$351,485\", \r\n\"status\": \"approved-Delegation\",
+        \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-04T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0379\", \r\n\"description\":
+        \"Dwelling House\", \r\n\"determination_date\": \"2016-03-04T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhHbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 120, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GILLIESTON HEIGHTS\",
+        \r\n\"postcode\": \"2321\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 Lavender
+        Close\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1194709\", \r\n\"lot\": \"132\", \r\n\"section\": null}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"ORACLE
+        BUILDING CORPORATION\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"NOT SPECIFIED\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"residential\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$342,050\", \r\n\"status\": \"Pending\",
+        \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"authority\": {\r\n\"name\": \"Maitland City
+        Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Luke Johnson\", \r\n\"dat_id\": \"DA-2016-0383\", \r\n\"description\":
+        \"Dual Occupancy \\/ Duplex\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9MDJZRABCQFRRRwhGbBoWAylEEhQ%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 119, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"LORN\", \r\n\"postcode\":
+        \"2320\", \r\n\"state\": \"NSW\", \r\n\"street\": \"5 Leslie Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP6373\", \r\n\"lot\":
+        \"15\", \r\n\"section\": \"7\"}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [151.562000, \r\n-32.729900]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"No Events\", \r\n\"timestamp\":
+        \"2016-02-24T00:00:00Z\", \r\n\"id\": \"0\", \r\n\"event_type\": \"NIL\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Mark and
+        Kellie Lantry\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"MARK
+        and KELLIE LANTRY\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"unknown\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\":
+        \"approved-Delegation\", \r\n\"lodgement_date\": \"2016-02-24T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-02-29T00:00:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Maitland City Council\", \r\n\"ref\": \"https:\\/\\/myhorizon.maitland.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Daniel Beckett\", \r\n\"dat_id\": \"DA-2016-0382\", \r\n\"description\":
+        \"Tree Application\", \r\n\"determination_date\": \"2016-02-29T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n] \r\n, \r\n\"count\": 20,
+        \r\n\"pagination\": {\r\n\"pages\": 7, \r\n\"per_page\": 20, \r\n\"next\":
+        7, \r\n\"previous\": 5, \r\n\"count\": 133, \r\n\"current\": 6}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:21:30 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ATDISPlanningAlertsFeed/really_dodgy_pagination/should_not_error.yml
+++ b/spec/cassettes/ATDISPlanningAlertsFeed/really_dodgy_pagination/should_not_error.yml
@@ -1,0 +1,1661 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0/applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:44:39 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000053.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-22T09:16:40+11:00","description":"dwelling
+        with attached double garage","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-21T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$420,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000053.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        1191730"}},"address":{"street":"7B Stewart PL","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006816","timestamp":"2016-03-22T09:16:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21655","title":"10.2016.53.1
+        -Public Plans - 7B Stewart PLace Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=ghfxuupNqI4="}],"people":[{"name":"Raymond
+        Vincent Constructions Pty Ltd","role":"Applicant","contact":"4422 5050"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000052.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-22T08:55:03+11:00","description":"demolition
+        of existing garage & dwelling additions including new garage","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$320,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000052.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"172","section":null,"dpsp_id":"DP
+        804643"}},"address":{"street":"539 Jamberoo RD","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006814","timestamp":"2016-03-22T08:55:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21649","title":"10.2016.52.1
+        - Public Plans - 539 Jamberoo Road Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=2O+KALUct7g="}],"people":[{"name":"Marie-Louise
+        Williams","role":"Applicant","contact":null},{"name":"Steven Williams","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000050.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-22T08:35:07+11:00","description":"dwelling,
+        swimming pool and retaining walls","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T14:46:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$750,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000050.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"16 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006813","timestamp":"2016-03-22T08:35:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006906","timestamp":"2016-03-22T14:46:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21778","title":"10.2016.50.1
+        - Public Plans - 16 O''Mara Place Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=JwGH80C/j74="}],"people":[{"name":"Killmore
+        & Sons Pty Ltd","role":"Applicant","contact":"4232 4513"},{"name":"Owner to
+        Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000051.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-22T08:28:34+11:00","description":"use
+        of existing awning and proposed swimming pool and deck addition","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$45,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000051.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"529","section":null,"dpsp_id":"DP
+        1111492"}},"address":{"street":"49 Union WY","suburb":"GERRINGONG","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1006811","timestamp":"2016-03-22T08:28:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21570","title":"10.2016.51.1
+        - Public Plans - 49 Union Way Gerringong","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=bVFv4gp5Fbw="}],"people":[{"name":"AjF
+        Designs","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000049.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-21T16:21:15+11:00","description":"carport","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-17T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T14:27:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$14,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000049.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"148","section":null,"dpsp_id":"DP
+        260154"}},"address":{"street":"10 Hoskings CR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006774","timestamp":"2016-03-21T16:21:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006903","timestamp":"2016-03-22T14:27:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21357","title":"10.2016.49.1
+        - Public Plans - 10 Hoskings Crescent Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=i+0uevZPbPI="}],"people":[{"name":"Beth
+        Canniford","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2013.00000064.002","development_type":"Residential
+        - Alterations & Additions","application_type":"S96","last_modified_date":"2016-03-21T15:39:09+11:00","description":"modified
+        - dwelling alterations & additions","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$80,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000064.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2013.00000064.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"17","section":null,"dpsp_id":"DP
+        554453"}},"address":{"street":"82 Collins ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006767","timestamp":"2016-03-21T15:39:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21455","title":"10.2013.64.2
+        - Public Plans -  82 Collins Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=mBE02EsdPBQ="}],"people":[{"name":"AjF
+        Designs","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000048.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-18T09:29:41+11:00","description":"dwelling
+        and retaining wall","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-17T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T13:49:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$450,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000048.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"DP
+        773150"}},"address":{"street":"37 Macquarie ST","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006415","timestamp":"2016-03-18T09:29:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006874","timestamp":"2016-03-22T13:49:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20814","title":"10.2016.48.1
+        - Public Plans -  37 Macquarie Street Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=/VXSkO2eTs4="}],"people":[{"name":"Killmore
+        & Sons Pty Ltd","role":"Applicant","contact":"4232 4513"},{"name":"Owner to
+        Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000047.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-18T09:26:19+11:00","description":"attached
+        deck & awning","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-17T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T13:32:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$15,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000047.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1000","section":null,"dpsp_id":"DP
+        236616"}},"address":{"street":"173 North Kiama DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006414","timestamp":"2016-03-18T09:26:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006870","timestamp":"2016-03-22T13:32:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21075","title":"10.2016.47.1
+        - Public Plans - 173 North Kiama Drive Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=gt3cKA7QTc4="}],"people":[{"name":"David
+        Kay","role":"Applicant","contact":null},{"name":"Sandra Kay","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000046.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-18T09:19:34+11:00","description":"use
+        of partially constructed deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T13:10:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$5,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000046.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"91","section":null,"dpsp_id":"DP
+        261909"}},"address":{"street":"18 Barton DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006412","timestamp":"2016-03-18T09:19:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006864","timestamp":"2016-03-22T13:10:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/22007","title":"10.2016.46.1
+        - Public plan - 18 Barton Drive Kiama Downs - James Schadel","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=r+JcefTOZVg="}],"people":[{"name":"James
+        Schadel","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000045.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-18T08:56:54+11:00","description":"use
+        of reconstructed shed","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T14:07:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$8,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000045.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"81","section":null,"dpsp_id":"DP
+        29245"}},"address":{"street":"12 Boyd ST","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006411","timestamp":"2016-03-18T08:57:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006877","timestamp":"2016-03-22T14:07:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21760","title":"10.2016.45.1
+        - Public Plans - 12 Boyd Street Minnamurra","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=DBuSmJVM0Tc="}],"people":[{"name":"Christie
+        Pulbrook","role":"Applicant","contact":null},{"name":"John Pulbrook","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":null,"next":2,"current":1,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:41:33 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0/applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:44:52 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000044.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-18T08:18:00+11:00","description":"storage
+        shed","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T11:33:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Herbert","estimated_cost":"$5,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000044.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        758563"}},"address":{"street":"2 Bong Bong ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006410","timestamp":"2016-03-18T08:18:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006848","timestamp":"2016-03-22T11:33:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20666","title":"10.2016.44.1
+        - Public Plans - 2 Bong Bong Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=c83+elqCXrI="}],"people":[{"name":"Kiama
+        Junior & Minor Rugby League","role":"Applicant","contact":"4232 2013"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000142.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-17T14:39:32+11:00","description":"modified
+        - three (3) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-23T00:00:00+11:00","determination_date":"2016-03-14T00:00:00+11:00","determination_type":"Approved
+        under delegation","status":"Determined","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000142.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000142.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"48","section":null,"dpsp_id":"DP
+        779575"}},"address":{"street":"15 Wyalla RD","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1002870","timestamp":"2016-02-24T09:49:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1002871","timestamp":"2016-02-24T09:49:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1003065","timestamp":"2016-02-24T16:29:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005516","timestamp":"2016-03-10T13:54:00+11:00","description":"Modified
+        App Assessment","event_type":"S96","status":"APPR"}],"documents":[],"people":[{"name":"Clifford
+        Mason","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000019.003","development_type":"Other","application_type":"S96","last_modified_date":"2016-03-17T12:07:26+11:00","description":"modified
+        - use of access driveway, viewing platform, grape & olive grove & use of land
+        for occasional private functions including weddings","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-15T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$380,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000019.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000019.002.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000019.003/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        931474"}},"address":{"street":"382 Minnamurra LA","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006218","timestamp":"2016-03-16T16:04:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[],"people":[{"name":"Allen
+        Price & Associates Pty Ltd","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2011.00000086.022","development_type":"Residential
+        - Seniors Living","application_type":"S96","last_modified_date":"2016-03-17T11:54:14+11:00","description":"modified
+        - demolition of an existing dwelling & construction of retirement village,
+        comprising of twenty nine (29) self-care strata titled single storey dwellings,
+        a community  room\nand private internal access road ( Lot 3 DP 270898 3 Arnold
+        Crescent)","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T10:57:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$11,485,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.002.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.003.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.004.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.005.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.006.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.007.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.008.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.009.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.010.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.011.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.012.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.013.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.014.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.015.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.016.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.017.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.018.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.019.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.020.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.021.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2011.00000086.022/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        1003719"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"1 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"3","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"3 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"5 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"5","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"7 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"6","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"9 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"11 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"13 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"9","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"15 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"10","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"17 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"11","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"14 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"12","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"16 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"13","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"22 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"14","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"24 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"15","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"25 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"16","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"27 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"17","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"29 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"18","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"31 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"19","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"33 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"20","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"35 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"21","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"34 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"22","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"8 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"23","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"10 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"24","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"12 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"25","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"18 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"26","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"20 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"27","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"26 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"28","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"28 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"29","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"30 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"30","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"32 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"19 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006297","timestamp":"2016-03-17T11:54:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006445","timestamp":"2016-03-18T10:57:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20586","title":"10.2011.86.22
+        - Public Plans - 3 Arnold Crescent Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=1kMJoGfJTlg="}],"people":[{"name":"Janet
+        Barnes","role":"Applicant","contact":null},{"name":"Robert Barnes","role":"Applicant","contact":null},{"name":"Kiama
+        Municipal Council","role":"Principal Certifying Authority","contact":"4232
+        0444"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000043.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T11:48:33+11:00","description":"attached
+        awning","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-15T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T12:04:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$10,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000043.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"267","section":null,"dpsp_id":"DP
+        14188"}},"address":{"street":"39 Werri ST","suburb":"WERRI BEACH","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1006293","timestamp":"2016-03-17T11:48:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006494","timestamp":"2016-03-18T12:04:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/19972","title":"10.2016.43.1
+        - Public Plans -  39 Werri Street Werri Beach","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=6gbq/vXpOiA="}],"people":[{"name":"Kathryn
+        Cummins","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000042.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T11:11:25+11:00","description":"additions
+        to existing deck & internal alterations","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-11T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T12:53:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$45,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000042.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"327","section":null,"dpsp_id":"DP
+        33903"}},"address":{"street":"52 Tingira CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006287","timestamp":"2016-03-17T11:11:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006519","timestamp":"2016-03-18T12:53:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20693","title":"10.2016.42.1
+        - Public Plans - 52 Tingira Crescent Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=RpKuuat31a0="}],"people":[{"name":"Justin
+        Streamer","role":"Applicant","contact":null},{"name":"Sarah Streamer","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000041.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-17T10:04:29+11:00","description":"proposed
+        attached dual occupancy and strata subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-11T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T12:40:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Brett
+        Elliott","estimated_cost":"$880,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000041.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"5204","section":null,"dpsp_id":"DP
+        1210287"}},"address":{"street":"3 Bourrool ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006254","timestamp":"2016-03-17T10:04:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006512","timestamp":"2016-03-18T12:40:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1006513","timestamp":"2016-03-18T12:41:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006515","timestamp":"2016-03-18T12:41:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":null},{"id":"1006516","timestamp":"2016-03-18T12:41:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":null},{"id":"1006517","timestamp":"2016-03-18T12:41:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null}],"documents":[{"ref":"16/21150","title":"10.2016.41.1
+        - Public plans - 3 Bourrool Street Kiama - A J and K A Turnbull","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=2vvHECheO0k="}],"people":[{"name":"Adrian
+        Turnbull","role":"Applicant","contact":null},{"name":"Kerry Turnbull","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000040.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-17T09:22:18+11:00","description":"dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-10T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T16:30:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$480,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000040.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"19 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006246","timestamp":"2016-03-17T09:22:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006369","timestamp":"2016-03-17T15:55:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006370","timestamp":"2016-03-17T15:56:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1006384","timestamp":"2016-03-18T16:30:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/19454","title":"10.2016.40.1
+        - NOT USED - Public Plans - 19 O''Mara Place Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=CJny5cpAsYc="}],"people":[{"name":"G
+        J Gardner Homes Wollongong","role":"Applicant","contact":"4256 4242"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000039.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T09:15:53+11:00","description":"addition
+        to unit one (1) within an existing dual occupancy","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-10T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$40,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000039.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"SP
+        33196"}},"address":{"street":"1/3 Weston PL","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006245","timestamp":"2016-03-17T09:15:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/19421","title":"10.2016.39.1
+        - Public Plans - 1/3 Weston Place Kiama -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=YH+KNoxyizk="}],"people":[{"name":"Local
+        Consultancy Services Pty Ltd","role":"Applicant","contact":"9002 9603"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000038.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T08:51:30+11:00","description":"two
+        (2) attached awnings","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-10T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$19,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000038.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"19 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006236","timestamp":"2016-03-17T08:51:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/19405","title":"10.2016.38.1
+        - Public Plans - 19 Arnold Crescent Kiama -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=FdVbgUY5QLk="}],"people":[{"name":"Stylemaster
+        Patios","role":"Applicant","contact":"1300761201"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":1,"next":3,"current":2,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:41:46 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0/applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:45:05 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2013.00000165.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-16T16:29:59+11:00","description":"modified
+        - demolition of existing dwelling & addition of three (3) residential units
+        & three (3) lot strata subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-11T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$2,380,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000165.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2013.00000165.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"A","section":null,"dpsp_id":"DP
+        384607"}},"address":{"street":"10 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006220","timestamp":"2016-03-16T16:30:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006335","timestamp":"2016-03-17T14:27:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006337","timestamp":"2016-03-17T14:27:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":null},{"id":"1006338","timestamp":"2016-03-17T14:27:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/19484","title":"10.2013.165.2
+        - Public Plans - 10 Barney Street Kiama -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=CygR3X6XoXQ="}],"people":[{"name":"Terrence
+        Graham","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2013.00000089.003","development_type":"Other","application_type":"S96","last_modified_date":"2016-03-16T15:52:06+11:00","description":"modified
+        - demolition of existing dwelling and erection of new dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-15T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Brett
+        Elliott","estimated_cost":"$900,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000089.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000089.002.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2013.00000089.003/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"893","section":null,"dpsp_id":"DP
+        736207"}},"address":{"street":"75 Crooked River RD","suburb":"GERROA","state":"NSW","postcode":"2534"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"120","section":null,"dpsp_id":"DP
+        1195604"}},"address":{"street":"75 Crooked River RD","suburb":"GERROA","state":"NSW","postcode":"2534"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"121","section":null,"dpsp_id":"DP
+        1195604"}},"address":{"street":"Crooked River RD","suburb":"GERROA","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1006216","timestamp":"2016-03-16T15:53:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006305","timestamp":"2016-03-17T12:10:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006306","timestamp":"2016-03-17T12:10:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":null},{"id":"1006307","timestamp":"2016-03-17T12:10:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/20507","title":"10.2013.89.3
+        - Public Plans - 75 Crooked River Road Gerroa","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=RmWae4TyNPM="}],"people":[{"name":"Strongbuild","role":"Applicant","contact":"02
+        4464 1179"},{"name":"Accredited Inspection Services Pty Ltd","role":"Principal
+        Certifying Authority","contact":"4421 0004"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000030.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-16T08:29:55+11:00","description":"single
+        storey dwelling with detached garage & granny flat, water tank photovolatic
+        solar panels & building envelope adjustment.","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-01T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$527,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000030.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"202","section":null,"dpsp_id":"DP
+        1210365"}},"address":{"street":"88 Wilsons RD","suburb":"SADDLEBACK MOUNTAIN","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004000","timestamp":"2016-03-02T14:58:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004132","timestamp":"2016-03-03T10:53:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004152","timestamp":"2016-03-03T11:42:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004154","timestamp":"2016-03-03T11:42:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1004155","timestamp":"2016-03-03T11:42:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/16206","title":"10.2016.30.1
+        - Public Plans -  88 Wilsons Road Saddleback Mountain","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=O5/ZkK7xRBY="}],"people":[{"name":"omes
+        Schofield Constructions Pty Ltd T/as Belle Abbey H","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000031.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-16T08:29:14+11:00","description":"detached
+        dual occupancy & two (2) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-01T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$500,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000031.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"21","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"15 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003916","timestamp":"2016-03-02T10:28:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004163","timestamp":"2016-03-03T12:01:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004177","timestamp":"2016-03-03T12:58:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004179","timestamp":"2016-03-03T12:58:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1004180","timestamp":"2016-03-03T12:58:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1004181","timestamp":"2016-03-03T12:58:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":"COMP"}],"documents":[{"ref":"16/16156","title":"10.2016.31.1
+        - Public Plans -  15 O''Mara Place Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=iSPBlULfOIs="}],"people":[{"name":"Pecorp
+        Design","role":"Applicant","contact":"4275 1999"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000033.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-11T10:26:15+11:00","description":"three
+        (3) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000033.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"32","section":null,"dpsp_id":"DP
+        1056234"}},"address":{"street":"94 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"50","section":null,"dpsp_id":"DP
+        1204232"}},"address":{"street":"45 Irvine ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"51","section":null,"dpsp_id":"DP
+        1204232"}},"address":{"street":"94 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"52","section":null,"dpsp_id":"DP
+        1204232"}},"address":{"street":"96 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004227","timestamp":"2016-03-03T15:00:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004439","timestamp":"2016-03-04T10:45:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004444","timestamp":"2016-03-04T11:11:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004446","timestamp":"2016-03-04T11:12:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1004447","timestamp":"2016-03-04T11:12:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1004448","timestamp":"2016-03-04T11:12:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":"COMP"},{"id":"1004452","timestamp":"2016-03-04T11:15:00+11:00","description":"Heritage
+        Officer Referral","event_type":"HERT","status":null}],"documents":[{"ref":"16/17304","title":"10.2016.33.1
+        - Notification Plans - 94 Barney Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=pUc6QdrAc2E="}],"people":[{"name":"Allen
+        Price & Associates Pty Ltd","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000186.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-09T16:14:27+11:00","description":"modified
+        - attached dual occupancy & two (2) lot strata title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-09T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$440,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000186.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000186.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"20","section":null,"dpsp_id":"DP
+        1093638"}},"address":{"street":"63 Minnamurra ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006037","timestamp":"2016-03-15T16:16:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006081","timestamp":"2016-03-16T10:16:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006083","timestamp":"2016-03-16T10:16:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1006084","timestamp":"2016-03-16T10:16:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null}],"documents":[{"ref":"16/19393","title":"10.2015.186.2
+        - Public Plans - 63 Minnamurra Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=H+7ucDyzdA4="}],"people":[{"name":"Minnamurra
+        Street Pty Ltd","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.1998.00000299.002","development_type":"Commercial
+        / retail / office","application_type":"S96","last_modified_date":"2016-03-09T09:59:16+11:00","description":"modified
+        - refurbishment of existing shop & establishment of a bakery & fascia sign","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-04T00:00:00+11:00","determination_date":"2016-03-09T00:00:00+11:00","determination_type":"Approved
+        under delegation","status":"Determined","notification_start_date":null,"notification_end_date":null,"officer":"Christopher
+        Fuller","estimated_cost":"$80,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.1998.00000299.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.1998.00000299.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"983","section":null,"dpsp_id":"DP
+        236617"}},"address":{"street":"21 Johnson ST","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1005204","timestamp":"2016-03-09T09:22:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005208","timestamp":"2016-03-09T09:31:00+11:00","description":"Modified
+        App Assessment","event_type":"S96","status":"COMP"},{"id":"1005256","timestamp":"2016-03-09T10:00:00+11:00","description":"Modified
+        DA Plans Released","event_type":"D5","status":"COMP"}],"documents":[],"people":[{"name":"Kathryn
+        Telford","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000022.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-08T16:32:43+11:00","description":"use
+        of black beach for three (3) day festival","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-22T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000022.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"7008","section":null,"dpsp_id":"DP
+        1074746"}},"address":{"street":"Terralong ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1002627","timestamp":"2016-02-23T09:38:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1002776","timestamp":"2016-02-23T14:38:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1002777","timestamp":"2016-02-23T14:39:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1002778","timestamp":"2016-02-23T14:40:00+11:00","description":"Manager
+        Property","event_type":"PROP","status":"COMP"},{"id":"1002779","timestamp":"2016-02-23T14:40:00+11:00","description":"EHO
+        Referral","event_type":"EHO","status":null},{"id":"1002780","timestamp":"2016-02-23T14:40:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1002781","timestamp":"2016-02-23T14:40:00+11:00","description":"Waste
+        Management Officer","event_type":"WMO","status":null}],"documents":[],"people":[{"name":"David
+        Evans","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000292.002","development_type":"Residential
+        - Alterations & Additions","application_type":"S96","last_modified_date":"2016-03-08T13:45:37+11:00","description":"modified
+        - dwelling alterations and additions and attached deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-07T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-08T14:19:00+11:00","notification_end_date":"2016-03-22T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$60,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000292.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000292.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"41","section":null,"dpsp_id":"DP
+        1087766"}},"address":{"street":"101B Tingira CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004982","timestamp":"2016-03-08T08:51:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005123","timestamp":"2016-03-08T14:19:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/18021","title":"10.2015.292.2
+        - Public Plans - 101B Tingira street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=nZD/76sl+Ms="}],"people":[{"name":"AjF
+        Designs","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000037.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-08T08:31:39+11:00","description":"three
+        (3) lot residential subdivision including demolition of garage to facilitate
+        access","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-04T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T13:57:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Dialina
+        Day","estimated_cost":"$6,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000037.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"327","section":null,"dpsp_id":"DP
+        703905"}},"address":{"street":"88 Barton DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004977","timestamp":"2016-03-08T08:31:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005306","timestamp":"2016-03-09T13:57:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1005307","timestamp":"2016-03-09T13:57:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1005309","timestamp":"2016-03-09T13:58:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1005310","timestamp":"2016-03-09T13:58:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1005311","timestamp":"2016-03-09T13:58:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null}],"documents":[{"ref":"16/17605","title":"10.2016.37.1
+        - Public Plans -  88 Barton Drive Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=PJvYRbibIek="}],"people":[{"name":"Allen
+        Price & Scarratts","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":2,"next":4,"current":3,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:42:00 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0/applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:45:20 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000036.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-07T15:14:30+11:00","description":"demolition
+        of existing dwelling & ancillary structures","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-03T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T11:47:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$10,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000036.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"280","section":null,"dpsp_id":"DP
+        14188"}},"address":{"street":"69 Werri ST","suburb":"WERRI BEACH","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1004917","timestamp":"2016-03-07T15:14:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005268","timestamp":"2016-03-09T11:47:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1005497","timestamp":"2016-03-10T13:16:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1005499","timestamp":"2016-03-10T13:17:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1005500","timestamp":"2016-03-10T13:17:00+11:00","description":"EHO
+        Referral","event_type":"EHO","status":null},{"id":"1006812","timestamp":"2016-03-22T08:32:00+11:00","description":"Additional
+        Information Request","event_type":"INFO","status":null}],"documents":[{"ref":"16/18589","title":"10.2016.36.1
+        - Public Plan - 69 Werri Street Werri Beach - Floorspace Design","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=xl5QT8DXCXc="}],"people":[{"name":"Floorspace
+        Design","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000035.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-07T09:51:21+11:00","description":"dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-03T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T11:23:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$275,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000035.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"10 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004788","timestamp":"2016-03-07T09:51:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005254","timestamp":"2016-03-09T11:23:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1006599","timestamp":"2016-03-18T16:28:00+11:00","description":"Additional
+        Information Request","event_type":"INFO","status":null}],"documents":[{"ref":"16/17609","title":"10.2016.35.1
+        - Public Plans -  10 O''Mara Place Jamberoo - Floorspace Design","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=YdBDs6q/Paw="}],"people":[{"name":"Floorspace
+        Design","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000034.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-07T09:43:55+11:00","description":"two
+        (2) torrens title subdivisions & retaining wall","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T15:53:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Dialina
+        Day","estimated_cost":"$5,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000034.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        784876"}},"address":{"street":"41 Churchill ST","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004787","timestamp":"2016-03-07T09:43:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005158","timestamp":"2016-03-08T15:53:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1005159","timestamp":"2016-03-08T15:54:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1005160","timestamp":"2016-03-08T15:54:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null},{"id":"1005157","timestamp":"2016-03-09T15:53:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/17669","title":"10.2016.34.1
+        - Public Plans -  41 Churchill Street Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=AimtC5ctXjI="}],"people":[{"name":"Plannex
+        Environmental Planning - Vortex Pty Ltd","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000246.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-07T09:30:52+11:00","description":"modified
+        - eight (8) lot strata subdivision (boundary adjustment) of an existing strata
+        scheme","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-04T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000246.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000246.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"1/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"2/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"3","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"3/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"5","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"5/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"6","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"6/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"7/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"8/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"0","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"9","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"8/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004785","timestamp":"2016-03-07T09:31:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004924","timestamp":"2016-03-07T15:22:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004925","timestamp":"2016-03-07T15:22:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1004926","timestamp":"2016-03-07T15:22:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":"COMP"}],"documents":[{"ref":"16/17658","title":"10.2015.246.2
+        -Public Plans -  154 Charles Avenue Minnamurra","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=q9FTiZ+/drM="}],"people":[{"name":"Allen
+        Price & Scarratts","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000055.002","development_type":"Residential
+        - Alterations & Additions","application_type":"S96","last_modified_date":"2016-03-07T09:21:33+11:00","description":"modified
+        - dwelling & swimming pool","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-08T14:56:00+11:00","notification_end_date":"2016-03-22T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$700,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000055.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000055.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"10","section":null,"dpsp_id":"DP
+        850163"}},"address":{"street":"7 Myuna PL","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004784","timestamp":"2016-03-07T09:21:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005132","timestamp":"2016-03-08T14:56:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/17641","title":"10.2015.55.2
+        - Public Plans - 7 Myuna Place Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=6NkVIU1rzgY="}],"people":[{"name":"Design
+        Matters","role":"Applicant","contact":"4272 8517"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000032.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-03T14:40:11+11:00","description":"alterations
+        & additions to existing dwelling including new verandahs & first floor addition
+        and carport","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$232,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000032.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"228","section":null,"dpsp_id":"DP
+        30200"}},"address":{"street":"72 North Kiama DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004222","timestamp":"2016-03-03T14:40:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004347","timestamp":"2016-03-04T08:46:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004392","timestamp":"2016-03-04T09:20:00+11:00","description":"State
+        Rail Referral","event_type":"SRA","status":null},{"id":"1006689","timestamp":"2016-03-21T11:20:00+11:00","description":"Additional
+        Information Request","event_type":"INFO","status":null}],"documents":[{"ref":"16/16894","title":"10.2016.32.1
+        - Public Plans -  72 North Kiama Drive Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=QJEm8SqMJKw="}],"people":[{"name":"Anthony
+        Tannous","role":"Applicant","contact":null},{"name":"Felicity Tannous","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000029.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-02T09:36:25+11:00","description":"extension
+        of deck & additional privacy screens to existing deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-25T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$55,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000029.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"24","section":null,"dpsp_id":"DP
+        1123051"}},"address":{"street":"43 Geering ST","suburb":"GERRINGONG","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1003894","timestamp":"2016-03-02T09:36:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004200","timestamp":"2016-03-03T13:51:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/15325","title":"10.2016.29.1
+        - Public Plans -  43 Geering Street Gerringong","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=lHBfm9TpcWA="}],"people":[{"name":"Robert
+        Dubler","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000028.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-02T09:25:48+11:00","description":"dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-25T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$252,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000028.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"23","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"10 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003890","timestamp":"2016-03-02T09:26:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004223","timestamp":"2016-03-03T14:49:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/15481","title":"10.2016.28.1
+        - Public Plan -  10 Arnold Crescent Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=D6GKKpWnkaE="}],"people":[{"name":"Beechwood
+        Homes (South Coast)","role":"Applicant","contact":"4423 0000"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2000.00000246.003","development_type":"Residential
+        - New multi unit","application_type":"S96","last_modified_date":"2016-03-02T09:19:00+11:00","description":"residential
+        flat building containing eighteen (18) units","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-24T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$1,000,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2000.00000246.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2000.00000246.002.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2000.00000246.003/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        827197"}},"address":{"street":"2 Hothersal ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003618","timestamp":"2016-02-29T16:13:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003887","timestamp":"2016-03-02T09:05:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003888","timestamp":"2016-03-02T09:05:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1003889","timestamp":"2016-03-02T09:05:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[],"people":[{"name":"Artro
+        Management Pty Ltd","role":"Applicant","contact":"02 9317 4833"},{"name":"Accredited
+        Building Certifiers Pty Ltd","role":"Principal Certifying Authority","contact":"4229
+        5309"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2011.00000086.021","development_type":"Residential
+        - Seniors Living","application_type":"S96","last_modified_date":"2016-03-02T08:54:32+11:00","description":"modified
+        - demolition of an existing dwelling and construction retirement village comprising
+        of twenty nine (29) self-care strata titled single storey dwellings, a community
+        room and private internal access road (lot 15, DP 270898 - 25 Arnold Crescent)","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-01T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$11,485,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.002.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.003.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.004.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.005.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.006.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.007.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.008.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.009.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.010.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.011.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.012.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.013.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.014.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.015.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.016.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.017.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.018.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.019.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.020.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.022.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2011.00000086.021/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        1003719"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"1 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"3","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"3 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"5 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"5","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"7 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"6","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"9 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"11 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"13 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"9","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"15 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"10","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"17 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"11","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"14 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"12","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"16 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"13","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"22 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"14","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"24 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"15","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"25 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"16","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"27 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"17","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"29 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"18","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"31 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"19","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"33 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"20","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"35 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"21","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"34 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"22","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"8 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"23","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"10 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"24","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"12 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"25","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"18 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"26","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"20 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"27","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"26 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"28","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"28 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"29","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"30 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"30","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"32 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"19 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003882","timestamp":"2016-03-02T08:54:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003909","timestamp":"2016-03-02T10:12:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/16203","title":"10.2011.86.21
+        - Public Plans -  25 Arnold Crescent -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=Gz+BnOC95GM="}],"people":[{"name":"G
+        J Gardner Homes - Shoalhaven","role":"Applicant","contact":"4422 9400"},{"name":"Kiama
+        Municipal Council","role":"Principal Certifying Authority","contact":"4232
+        0444"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":3,"next":5,"current":4,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:42:14 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0/applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:45:28 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000024.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-02-29T14:37:27+11:00","description":"attached
+        dual occupancy and two (2) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-22T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$688,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000024.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"19","section":null,"dpsp_id":"DP
+        1206612"}},"address":{"street":"17 Northpoint PL","suburb":"BOMBO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003045","timestamp":"2016-02-24T15:52:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003125","timestamp":"2016-02-25T10:58:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1003127","timestamp":"2016-02-25T10:59:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003128","timestamp":"2016-02-25T10:59:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1003129","timestamp":"2016-02-25T10:59:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/14215","title":"10.2016.24.1
+        - Public Plans -  17 Northpoint Place Bombo - Craig White Building Design","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=+HByH3JiO3k="}],"people":[{"name":"Craig
+        White Building Design","role":"Applicant","contact":"4421 5796"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000023.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-02-29T14:37:09+11:00","description":"inground
+        swimming pool & removal of two (2) sheoak trees","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-22T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$19,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000023.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"C","section":null,"dpsp_id":"DP
+        156993"}},"address":{"street":"25 Campbell ST","suburb":"GERRINGONG","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1003042","timestamp":"2016-02-24T15:40:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003141","timestamp":"2016-02-25T11:23:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1003142","timestamp":"2016-02-25T11:24:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003143","timestamp":"2016-02-25T11:24:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"}],"documents":[{"ref":"16/13899","title":"10.2016.23.1
+        - Public Plan -  25 Campbell Street Gerringong","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=nv39HYyFeyg="}],"people":[{"name":"Narellan
+        Pools","role":"Applicant","contact":"4262 2211"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000027.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-02-24T16:50:26+11:00","description":"conversion
+        of existing lower floor of dwelling to secondary dwelling and addition of
+        a first floor deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-23T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$45,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000027.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        156317"}},"address":{"street":"136A Shoalhaven ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003070","timestamp":"2016-02-24T16:50:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003114","timestamp":"2016-02-25T10:07:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1003115","timestamp":"2016-02-25T10:08:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003116","timestamp":"2016-02-25T10:08:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[],"people":[{"name":"Set
+        Consultants Pty Ltd","role":"Applicant","contact":"4421 4500"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":3,"pagination":{"previous":4,"next":6,"current":5,"per_page":3,"count":43,"pages":15}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:42:22 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0/applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:45:28 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[],"count":0,"pagination":null}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:42:22 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:51:09 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000053.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-22T09:16:40+11:00","description":"dwelling
+        with attached double garage","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-21T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$420,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000053.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        1191730"}},"address":{"street":"7B Stewart PL","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006816","timestamp":"2016-03-22T09:16:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21655","title":"10.2016.53.1
+        -Public Plans - 7B Stewart PLace Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=ghfxuupNqI4="}],"people":[{"name":"Raymond
+        Vincent Constructions Pty Ltd","role":"Applicant","contact":"4422 5050"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000052.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-22T08:55:03+11:00","description":"demolition
+        of existing garage & dwelling additions including new garage","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$320,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000052.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"172","section":null,"dpsp_id":"DP
+        804643"}},"address":{"street":"539 Jamberoo RD","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006814","timestamp":"2016-03-22T08:55:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21649","title":"10.2016.52.1
+        - Public Plans - 539 Jamberoo Road Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=2O+KALUct7g="}],"people":[{"name":"Marie-Louise
+        Williams","role":"Applicant","contact":null},{"name":"Steven Williams","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000050.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-22T08:35:07+11:00","description":"dwelling,
+        swimming pool and retaining walls","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T14:46:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$750,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000050.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"16 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006813","timestamp":"2016-03-22T08:35:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006906","timestamp":"2016-03-22T14:46:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21778","title":"10.2016.50.1
+        - Public Plans - 16 O''Mara Place Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=JwGH80C/j74="}],"people":[{"name":"Killmore
+        & Sons Pty Ltd","role":"Applicant","contact":"4232 4513"},{"name":"Owner to
+        Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000051.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-22T08:28:34+11:00","description":"use
+        of existing awning and proposed swimming pool and deck addition","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$45,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000051.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"529","section":null,"dpsp_id":"DP
+        1111492"}},"address":{"street":"49 Union WY","suburb":"GERRINGONG","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1006811","timestamp":"2016-03-22T08:28:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21570","title":"10.2016.51.1
+        - Public Plans - 49 Union Way Gerringong","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=bVFv4gp5Fbw="}],"people":[{"name":"AjF
+        Designs","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000049.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-21T16:21:15+11:00","description":"carport","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-17T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T14:27:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$14,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000049.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"148","section":null,"dpsp_id":"DP
+        260154"}},"address":{"street":"10 Hoskings CR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006774","timestamp":"2016-03-21T16:21:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006903","timestamp":"2016-03-22T14:27:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21357","title":"10.2016.49.1
+        - Public Plans - 10 Hoskings Crescent Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=i+0uevZPbPI="}],"people":[{"name":"Beth
+        Canniford","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2013.00000064.002","development_type":"Residential
+        - Alterations & Additions","application_type":"S96","last_modified_date":"2016-03-21T15:39:09+11:00","description":"modified
+        - dwelling alterations & additions","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-18T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$80,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000064.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2013.00000064.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"17","section":null,"dpsp_id":"DP
+        554453"}},"address":{"street":"82 Collins ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006767","timestamp":"2016-03-21T15:39:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/21455","title":"10.2013.64.2
+        - Public Plans -  82 Collins Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=mBE02EsdPBQ="}],"people":[{"name":"AjF
+        Designs","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000048.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-18T09:29:41+11:00","description":"dwelling
+        and retaining wall","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-17T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T13:49:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$450,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000048.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"DP
+        773150"}},"address":{"street":"37 Macquarie ST","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006415","timestamp":"2016-03-18T09:29:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006874","timestamp":"2016-03-22T13:49:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20814","title":"10.2016.48.1
+        - Public Plans -  37 Macquarie Street Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=/VXSkO2eTs4="}],"people":[{"name":"Killmore
+        & Sons Pty Ltd","role":"Applicant","contact":"4232 4513"},{"name":"Owner to
+        Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000047.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-18T09:26:19+11:00","description":"attached
+        deck & awning","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-17T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T13:32:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$15,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000047.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1000","section":null,"dpsp_id":"DP
+        236616"}},"address":{"street":"173 North Kiama DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006414","timestamp":"2016-03-18T09:26:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006870","timestamp":"2016-03-22T13:32:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21075","title":"10.2016.47.1
+        - Public Plans - 173 North Kiama Drive Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=gt3cKA7QTc4="}],"people":[{"name":"David
+        Kay","role":"Applicant","contact":null},{"name":"Sandra Kay","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000046.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-18T09:19:34+11:00","description":"use
+        of partially constructed deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T13:10:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$5,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000046.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"91","section":null,"dpsp_id":"DP
+        261909"}},"address":{"street":"18 Barton DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006412","timestamp":"2016-03-18T09:19:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006864","timestamp":"2016-03-22T13:10:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/22007","title":"10.2016.46.1
+        - Public plan - 18 Barton Drive Kiama Downs - James Schadel","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=r+JcefTOZVg="}],"people":[{"name":"James
+        Schadel","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000045.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-18T08:56:54+11:00","description":"use
+        of reconstructed shed","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T14:07:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Joseph","estimated_cost":"$8,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000045.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"81","section":null,"dpsp_id":"DP
+        29245"}},"address":{"street":"12 Boyd ST","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006411","timestamp":"2016-03-18T08:57:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006877","timestamp":"2016-03-22T14:07:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/21760","title":"10.2016.45.1
+        - Public Plans - 12 Boyd Street Minnamurra","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=DBuSmJVM0Tc="}],"people":[{"name":"Christie
+        Pulbrook","role":"Applicant","contact":null},{"name":"John Pulbrook","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":null,"next":2,"current":1,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:06 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:51:17 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000044.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-18T08:18:00+11:00","description":"storage
+        shed","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-22T11:33:00+11:00","notification_end_date":"2016-04-05T00:00:00+10:00","officer":"Gregory
+        Herbert","estimated_cost":"$5,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000044.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        758563"}},"address":{"street":"2 Bong Bong ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006410","timestamp":"2016-03-18T08:18:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006848","timestamp":"2016-03-22T11:33:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20666","title":"10.2016.44.1
+        - Public Plans - 2 Bong Bong Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=c83+elqCXrI="}],"people":[{"name":"Kiama
+        Junior & Minor Rugby League","role":"Applicant","contact":"4232 2013"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000142.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-17T14:39:32+11:00","description":"modified
+        - three (3) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-23T00:00:00+11:00","determination_date":"2016-03-14T00:00:00+11:00","determination_type":"Approved
+        under delegation","status":"Determined","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000142.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000142.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"48","section":null,"dpsp_id":"DP
+        779575"}},"address":{"street":"15 Wyalla RD","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1002870","timestamp":"2016-02-24T09:49:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1002871","timestamp":"2016-02-24T09:49:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1003065","timestamp":"2016-02-24T16:29:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005516","timestamp":"2016-03-10T13:54:00+11:00","description":"Modified
+        App Assessment","event_type":"S96","status":"APPR"}],"documents":[],"people":[{"name":"Clifford
+        Mason","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000019.003","development_type":"Other","application_type":"S96","last_modified_date":"2016-03-17T12:07:26+11:00","description":"modified
+        - use of access driveway, viewing platform, grape & olive grove & use of land
+        for occasional private functions including weddings","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-15T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$380,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000019.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000019.002.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000019.003/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        931474"}},"address":{"street":"382 Minnamurra LA","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006218","timestamp":"2016-03-16T16:04:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[],"people":[{"name":"Allen
+        Price & Associates Pty Ltd","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2011.00000086.022","development_type":"Residential
+        - Seniors Living","application_type":"S96","last_modified_date":"2016-03-17T11:54:14+11:00","description":"modified
+        - demolition of an existing dwelling & construction of retirement village,
+        comprising of twenty nine (29) self-care strata titled single storey dwellings,
+        a community  room\nand private internal access road ( Lot 3 DP 270898 3 Arnold
+        Crescent)","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-16T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T10:57:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$11,485,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.002.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.003.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.004.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.005.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.006.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.007.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.008.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.009.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.010.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.011.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.012.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.013.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.014.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.015.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.016.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.017.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.018.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.019.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.020.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.021.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2011.00000086.022/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        1003719"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"1 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"3","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"3 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"5 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"5","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"7 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"6","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"9 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"11 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"13 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"9","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"15 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"10","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"17 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"11","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"14 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"12","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"16 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"13","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"22 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"14","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"24 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"15","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"25 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"16","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"27 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"17","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"29 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"18","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"31 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"19","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"33 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"20","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"35 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"21","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"34 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"22","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"8 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"23","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"10 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"24","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"12 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"25","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"18 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"26","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"20 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"27","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"26 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"28","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"28 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"29","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"30 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"30","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"32 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"19 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006297","timestamp":"2016-03-17T11:54:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006445","timestamp":"2016-03-18T10:57:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20586","title":"10.2011.86.22
+        - Public Plans - 3 Arnold Crescent Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=1kMJoGfJTlg="}],"people":[{"name":"Janet
+        Barnes","role":"Applicant","contact":null},{"name":"Robert Barnes","role":"Applicant","contact":null},{"name":"Kiama
+        Municipal Council","role":"Principal Certifying Authority","contact":"4232
+        0444"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000043.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T11:48:33+11:00","description":"attached
+        awning","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-15T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T12:04:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$10,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000043.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"267","section":null,"dpsp_id":"DP
+        14188"}},"address":{"street":"39 Werri ST","suburb":"WERRI BEACH","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1006293","timestamp":"2016-03-17T11:48:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006494","timestamp":"2016-03-18T12:04:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/19972","title":"10.2016.43.1
+        - Public Plans -  39 Werri Street Werri Beach","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=6gbq/vXpOiA="}],"people":[{"name":"Kathryn
+        Cummins","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000042.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T11:11:25+11:00","description":"additions
+        to existing deck & internal alterations","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-11T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T12:53:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$45,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000042.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"327","section":null,"dpsp_id":"DP
+        33903"}},"address":{"street":"52 Tingira CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006287","timestamp":"2016-03-17T11:11:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006519","timestamp":"2016-03-18T12:53:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/20693","title":"10.2016.42.1
+        - Public Plans - 52 Tingira Crescent Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=RpKuuat31a0="}],"people":[{"name":"Justin
+        Streamer","role":"Applicant","contact":null},{"name":"Sarah Streamer","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000041.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-17T10:04:29+11:00","description":"proposed
+        attached dual occupancy and strata subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-11T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T12:40:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Brett
+        Elliott","estimated_cost":"$880,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000041.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"5204","section":null,"dpsp_id":"DP
+        1210287"}},"address":{"street":"3 Bourrool ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006254","timestamp":"2016-03-17T10:04:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006512","timestamp":"2016-03-18T12:40:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1006513","timestamp":"2016-03-18T12:41:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006515","timestamp":"2016-03-18T12:41:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":null},{"id":"1006516","timestamp":"2016-03-18T12:41:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":null},{"id":"1006517","timestamp":"2016-03-18T12:41:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null}],"documents":[{"ref":"16/21150","title":"10.2016.41.1
+        - Public plans - 3 Bourrool Street Kiama - A J and K A Turnbull","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=2vvHECheO0k="}],"people":[{"name":"Adrian
+        Turnbull","role":"Applicant","contact":null},{"name":"Kerry Turnbull","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000040.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-17T09:22:18+11:00","description":"dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-10T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-18T16:30:00+11:00","notification_end_date":"2016-04-01T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$480,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000040.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"19 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006246","timestamp":"2016-03-17T09:22:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006369","timestamp":"2016-03-17T15:55:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006370","timestamp":"2016-03-17T15:56:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1006384","timestamp":"2016-03-18T16:30:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/19454","title":"10.2016.40.1
+        - NOT USED - Public Plans - 19 O''Mara Place Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=CJny5cpAsYc="}],"people":[{"name":"G
+        J Gardner Homes Wollongong","role":"Applicant","contact":"4256 4242"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000039.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T09:15:53+11:00","description":"addition
+        to unit one (1) within an existing dual occupancy","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-10T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$40,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000039.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"SP
+        33196"}},"address":{"street":"1/3 Weston PL","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006245","timestamp":"2016-03-17T09:15:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/19421","title":"10.2016.39.1
+        - Public Plans - 1/3 Weston Place Kiama -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=YH+KNoxyizk="}],"people":[{"name":"Local
+        Consultancy Services Pty Ltd","role":"Applicant","contact":"9002 9603"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000038.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-17T08:51:30+11:00","description":"two
+        (2) attached awnings","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-10T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$19,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000038.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"19 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006236","timestamp":"2016-03-17T08:51:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"}],"documents":[{"ref":"16/19405","title":"10.2016.38.1
+        - Public Plans - 19 Arnold Crescent Kiama -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=FdVbgUY5QLk="}],"people":[{"name":"Stylemaster
+        Patios","role":"Applicant","contact":"1300761201"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":1,"next":3,"current":2,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:12 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:51:26 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2013.00000165.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-16T16:29:59+11:00","description":"modified
+        - demolition of existing dwelling & addition of three (3) residential units
+        & three (3) lot strata subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-11T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$2,380,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000165.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2013.00000165.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"A","section":null,"dpsp_id":"DP
+        384607"}},"address":{"street":"10 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006220","timestamp":"2016-03-16T16:30:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006335","timestamp":"2016-03-17T14:27:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006337","timestamp":"2016-03-17T14:27:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":null},{"id":"1006338","timestamp":"2016-03-17T14:27:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/19484","title":"10.2013.165.2
+        - Public Plans - 10 Barney Street Kiama -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=CygR3X6XoXQ="}],"people":[{"name":"Terrence
+        Graham","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2013.00000089.003","development_type":"Other","application_type":"S96","last_modified_date":"2016-03-16T15:52:06+11:00","description":"modified
+        - demolition of existing dwelling and erection of new dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-15T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Brett
+        Elliott","estimated_cost":"$900,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000089.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2013.00000089.002.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2013.00000089.003/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"893","section":null,"dpsp_id":"DP
+        736207"}},"address":{"street":"75 Crooked River RD","suburb":"GERROA","state":"NSW","postcode":"2534"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"120","section":null,"dpsp_id":"DP
+        1195604"}},"address":{"street":"75 Crooked River RD","suburb":"GERROA","state":"NSW","postcode":"2534"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"121","section":null,"dpsp_id":"DP
+        1195604"}},"address":{"street":"Crooked River RD","suburb":"GERROA","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1006216","timestamp":"2016-03-16T15:53:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006305","timestamp":"2016-03-17T12:10:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006306","timestamp":"2016-03-17T12:10:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":null},{"id":"1006307","timestamp":"2016-03-17T12:10:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/20507","title":"10.2013.89.3
+        - Public Plans - 75 Crooked River Road Gerroa","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=RmWae4TyNPM="}],"people":[{"name":"Strongbuild","role":"Applicant","contact":"02
+        4464 1179"},{"name":"Accredited Inspection Services Pty Ltd","role":"Principal
+        Certifying Authority","contact":"4421 0004"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000030.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-16T08:29:55+11:00","description":"single
+        storey dwelling with detached garage & granny flat, water tank photovolatic
+        solar panels & building envelope adjustment.","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-01T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$527,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000030.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"202","section":null,"dpsp_id":"DP
+        1210365"}},"address":{"street":"88 Wilsons RD","suburb":"SADDLEBACK MOUNTAIN","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004000","timestamp":"2016-03-02T14:58:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004132","timestamp":"2016-03-03T10:53:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004152","timestamp":"2016-03-03T11:42:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004154","timestamp":"2016-03-03T11:42:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1004155","timestamp":"2016-03-03T11:42:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/16206","title":"10.2016.30.1
+        - Public Plans -  88 Wilsons Road Saddleback Mountain","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=O5/ZkK7xRBY="}],"people":[{"name":"omes
+        Schofield Constructions Pty Ltd T/as Belle Abbey H","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000031.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-16T08:29:14+11:00","description":"detached
+        dual occupancy & two (2) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-01T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$500,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000031.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"21","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"15 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003916","timestamp":"2016-03-02T10:28:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004163","timestamp":"2016-03-03T12:01:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004177","timestamp":"2016-03-03T12:58:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004179","timestamp":"2016-03-03T12:58:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1004180","timestamp":"2016-03-03T12:58:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1004181","timestamp":"2016-03-03T12:58:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":"COMP"}],"documents":[{"ref":"16/16156","title":"10.2016.31.1
+        - Public Plans -  15 O''Mara Place Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=iSPBlULfOIs="}],"people":[{"name":"Pecorp
+        Design","role":"Applicant","contact":"4275 1999"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000033.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-11T10:26:15+11:00","description":"three
+        (3) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000033.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"32","section":null,"dpsp_id":"DP
+        1056234"}},"address":{"street":"94 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"50","section":null,"dpsp_id":"DP
+        1204232"}},"address":{"street":"45 Irvine ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"51","section":null,"dpsp_id":"DP
+        1204232"}},"address":{"street":"94 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"52","section":null,"dpsp_id":"DP
+        1204232"}},"address":{"street":"96 Barney ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004227","timestamp":"2016-03-03T15:00:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004439","timestamp":"2016-03-04T10:45:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004444","timestamp":"2016-03-04T11:11:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004446","timestamp":"2016-03-04T11:12:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1004447","timestamp":"2016-03-04T11:12:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1004448","timestamp":"2016-03-04T11:12:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":"COMP"},{"id":"1004452","timestamp":"2016-03-04T11:15:00+11:00","description":"Heritage
+        Officer Referral","event_type":"HERT","status":null}],"documents":[{"ref":"16/17304","title":"10.2016.33.1
+        - Notification Plans - 94 Barney Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=pUc6QdrAc2E="}],"people":[{"name":"Allen
+        Price & Associates Pty Ltd","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000186.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-09T16:14:27+11:00","description":"modified
+        - attached dual occupancy & two (2) lot strata title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-09T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$440,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000186.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000186.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"20","section":null,"dpsp_id":"DP
+        1093638"}},"address":{"street":"63 Minnamurra ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1006037","timestamp":"2016-03-15T16:16:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1006081","timestamp":"2016-03-16T10:16:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1006083","timestamp":"2016-03-16T10:16:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1006084","timestamp":"2016-03-16T10:16:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null}],"documents":[{"ref":"16/19393","title":"10.2015.186.2
+        - Public Plans - 63 Minnamurra Street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=H+7ucDyzdA4="}],"people":[{"name":"Minnamurra
+        Street Pty Ltd","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.1998.00000299.002","development_type":"Commercial
+        / retail / office","application_type":"S96","last_modified_date":"2016-03-09T09:59:16+11:00","description":"modified
+        - refurbishment of existing shop & establishment of a bakery & fascia sign","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-04T00:00:00+11:00","determination_date":"2016-03-09T00:00:00+11:00","determination_type":"Approved
+        under delegation","status":"Determined","notification_start_date":null,"notification_end_date":null,"officer":"Christopher
+        Fuller","estimated_cost":"$80,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.1998.00000299.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.1998.00000299.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"983","section":null,"dpsp_id":"DP
+        236617"}},"address":{"street":"21 Johnson ST","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1005204","timestamp":"2016-03-09T09:22:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005208","timestamp":"2016-03-09T09:31:00+11:00","description":"Modified
+        App Assessment","event_type":"S96","status":"COMP"},{"id":"1005256","timestamp":"2016-03-09T10:00:00+11:00","description":"Modified
+        DA Plans Released","event_type":"D5","status":"COMP"}],"documents":[],"people":[{"name":"Kathryn
+        Telford","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000022.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-08T16:32:43+11:00","description":"use
+        of black beach for three (3) day festival","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-22T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000022.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"7008","section":null,"dpsp_id":"DP
+        1074746"}},"address":{"street":"Terralong ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1002627","timestamp":"2016-02-23T09:38:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1002776","timestamp":"2016-02-23T14:38:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1002777","timestamp":"2016-02-23T14:39:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1002778","timestamp":"2016-02-23T14:40:00+11:00","description":"Manager
+        Property","event_type":"PROP","status":"COMP"},{"id":"1002779","timestamp":"2016-02-23T14:40:00+11:00","description":"EHO
+        Referral","event_type":"EHO","status":null},{"id":"1002780","timestamp":"2016-02-23T14:40:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1002781","timestamp":"2016-02-23T14:40:00+11:00","description":"Waste
+        Management Officer","event_type":"WMO","status":null}],"documents":[],"people":[{"name":"David
+        Evans","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000292.002","development_type":"Residential
+        - Alterations & Additions","application_type":"S96","last_modified_date":"2016-03-08T13:45:37+11:00","description":"modified
+        - dwelling alterations and additions and attached deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-07T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-08T14:19:00+11:00","notification_end_date":"2016-03-22T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$60,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000292.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000292.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"41","section":null,"dpsp_id":"DP
+        1087766"}},"address":{"street":"101B Tingira CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004982","timestamp":"2016-03-08T08:51:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005123","timestamp":"2016-03-08T14:19:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/18021","title":"10.2015.292.2
+        - Public Plans - 101B Tingira street Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=nZD/76sl+Ms="}],"people":[{"name":"AjF
+        Designs","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000037.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-03-08T08:31:39+11:00","description":"three
+        (3) lot residential subdivision including demolition of garage to facilitate
+        access","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-04T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T13:57:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Dialina
+        Day","estimated_cost":"$6,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000037.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"327","section":null,"dpsp_id":"DP
+        703905"}},"address":{"street":"88 Barton DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004977","timestamp":"2016-03-08T08:31:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005306","timestamp":"2016-03-09T13:57:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1005307","timestamp":"2016-03-09T13:57:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1005309","timestamp":"2016-03-09T13:58:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1005310","timestamp":"2016-03-09T13:58:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1005311","timestamp":"2016-03-09T13:58:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null}],"documents":[{"ref":"16/17605","title":"10.2016.37.1
+        - Public Plans -  88 Barton Drive Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=PJvYRbibIek="}],"people":[{"name":"Allen
+        Price & Scarratts","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":2,"next":4,"current":3,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:21 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:51:34 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000036.001","development_type":"Other","application_type":"DA","last_modified_date":"2016-03-07T15:14:30+11:00","description":"demolition
+        of existing dwelling & ancillary structures","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-03T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T11:47:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Gregory
+        Herbert","estimated_cost":"$10,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000036.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"280","section":null,"dpsp_id":"DP
+        14188"}},"address":{"street":"69 Werri ST","suburb":"WERRI BEACH","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1004917","timestamp":"2016-03-07T15:14:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005268","timestamp":"2016-03-09T11:47:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1005497","timestamp":"2016-03-10T13:16:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1005499","timestamp":"2016-03-10T13:17:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1005500","timestamp":"2016-03-10T13:17:00+11:00","description":"EHO
+        Referral","event_type":"EHO","status":null},{"id":"1006812","timestamp":"2016-03-22T08:32:00+11:00","description":"Additional
+        Information Request","event_type":"INFO","status":null}],"documents":[{"ref":"16/18589","title":"10.2016.36.1
+        - Public Plan - 69 Werri Street Werri Beach - Floorspace Design","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=xl5QT8DXCXc="}],"people":[{"name":"Floorspace
+        Design","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000035.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-07T09:51:21+11:00","description":"dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-03T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T11:23:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$275,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000035.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        1193900"}},"address":{"street":"10 O''Mara PL","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004788","timestamp":"2016-03-07T09:51:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005254","timestamp":"2016-03-09T11:23:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1006599","timestamp":"2016-03-18T16:28:00+11:00","description":"Additional
+        Information Request","event_type":"INFO","status":null}],"documents":[{"ref":"16/17609","title":"10.2016.35.1
+        - Public Plans -  10 O''Mara Place Jamberoo - Floorspace Design","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=YdBDs6q/Paw="}],"people":[{"name":"Floorspace
+        Design","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000034.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-07T09:43:55+11:00","description":"two
+        (2) torrens title subdivisions & retaining wall","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-09T15:53:00+11:00","notification_end_date":"2016-03-23T00:00:00+11:00","officer":"Dialina
+        Day","estimated_cost":"$5,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000034.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        784876"}},"address":{"street":"41 Churchill ST","suburb":"JAMBEROO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004787","timestamp":"2016-03-07T09:43:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005158","timestamp":"2016-03-08T15:53:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1005159","timestamp":"2016-03-08T15:54:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1005160","timestamp":"2016-03-08T15:54:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":null},{"id":"1005157","timestamp":"2016-03-09T15:53:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/17669","title":"10.2016.34.1
+        - Public Plans -  41 Churchill Street Jamberoo","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=AimtC5ctXjI="}],"people":[{"name":"Plannex
+        Environmental Planning - Vortex Pty Ltd","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000246.002","development_type":"Subdivision
+        Only","application_type":"S96","last_modified_date":"2016-03-07T09:30:52+11:00","description":"modified
+        - eight (8) lot strata subdivision (boundary adjustment) of an existing strata
+        scheme","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-04T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$0.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000246.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000246.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"1/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"2/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"3","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"3/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"5","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"5/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"6","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"6/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"7/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"8/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"0","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"9","section":null,"dpsp_id":"SP
+        7236"}},"address":{"street":"8/154 Charles AV","suburb":"MINNAMURRA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004785","timestamp":"2016-03-07T09:31:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004924","timestamp":"2016-03-07T15:22:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1004925","timestamp":"2016-03-07T15:22:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"},{"id":"1004926","timestamp":"2016-03-07T15:22:00+11:00","description":"GIS
+        Officer","event_type":"GIS","status":"COMP"}],"documents":[{"ref":"16/17658","title":"10.2015.246.2
+        -Public Plans -  154 Charles Avenue Minnamurra","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=q9FTiZ+/drM="}],"people":[{"name":"Allen
+        Price & Scarratts","role":"Applicant","contact":"4421 6544"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2015.00000055.002","development_type":"Residential
+        - Alterations & Additions","application_type":"S96","last_modified_date":"2016-03-07T09:21:33+11:00","description":"modified
+        - dwelling & swimming pool","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":"2016-03-08T14:56:00+11:00","notification_end_date":"2016-03-22T00:00:00+11:00","officer":"Gregory
+        Joseph","estimated_cost":"$700,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2015.00000055.001.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2015.00000055.002/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"10","section":null,"dpsp_id":"DP
+        850163"}},"address":{"street":"7 Myuna PL","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004784","timestamp":"2016-03-07T09:21:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1005132","timestamp":"2016-03-08T14:56:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/17641","title":"10.2015.55.2
+        - Public Plans - 7 Myuna Place Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=6NkVIU1rzgY="}],"people":[{"name":"Design
+        Matters","role":"Applicant","contact":"4272 8517"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000032.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-03T14:40:11+11:00","description":"alterations
+        & additions to existing dwelling including new verandahs & first floor addition
+        and carport","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-02T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$232,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000032.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"228","section":null,"dpsp_id":"DP
+        30200"}},"address":{"street":"72 North Kiama DR","suburb":"KIAMA DOWNS","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1004222","timestamp":"2016-03-03T14:40:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004347","timestamp":"2016-03-04T08:46:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1004392","timestamp":"2016-03-04T09:20:00+11:00","description":"State
+        Rail Referral","event_type":"SRA","status":null},{"id":"1006689","timestamp":"2016-03-21T11:20:00+11:00","description":"Additional
+        Information Request","event_type":"INFO","status":null}],"documents":[{"ref":"16/16894","title":"10.2016.32.1
+        - Public Plans -  72 North Kiama Drive Kiama Downs","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=QJEm8SqMJKw="}],"people":[{"name":"Anthony
+        Tannous","role":"Applicant","contact":null},{"name":"Felicity Tannous","role":"Applicant","contact":null},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000029.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-03-02T09:36:25+11:00","description":"extension
+        of deck & additional privacy screens to existing deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-25T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$55,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000029.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"24","section":null,"dpsp_id":"DP
+        1123051"}},"address":{"street":"43 Geering ST","suburb":"GERRINGONG","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1003894","timestamp":"2016-03-02T09:36:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004200","timestamp":"2016-03-03T13:51:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/15325","title":"10.2016.29.1
+        - Public Plans -  43 Geering Street Gerringong","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=lHBfm9TpcWA="}],"people":[{"name":"Robert
+        Dubler","role":"Applicant","contact":null},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000028.001","development_type":"Residential
+        - Single new dwelling","application_type":"DA","last_modified_date":"2016-03-02T09:25:48+11:00","description":"dwelling","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-25T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$252,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000028.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"23","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"10 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003890","timestamp":"2016-03-02T09:26:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1004223","timestamp":"2016-03-03T14:49:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/15481","title":"10.2016.28.1
+        - Public Plan -  10 Arnold Crescent Kiama","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=D6GKKpWnkaE="}],"people":[{"name":"Beechwood
+        Homes (South Coast)","role":"Applicant","contact":"4423 0000"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2000.00000246.003","development_type":"Residential
+        - New multi unit","application_type":"S96","last_modified_date":"2016-03-02T09:19:00+11:00","description":"residential
+        flat building containing eighteen (18) units","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-24T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$1,000,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2000.00000246.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2000.00000246.002.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2000.00000246.003/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        827197"}},"address":{"street":"2 Hothersal ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003618","timestamp":"2016-02-29T16:13:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003887","timestamp":"2016-03-02T09:05:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003888","timestamp":"2016-03-02T09:05:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1003889","timestamp":"2016-03-02T09:05:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[],"people":[{"name":"Artro
+        Management Pty Ltd","role":"Applicant","contact":"02 9317 4833"},{"name":"Accredited
+        Building Certifiers Pty Ltd","role":"Principal Certifying Authority","contact":"4229
+        5309"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2011.00000086.021","development_type":"Residential
+        - Seniors Living","application_type":"S96","last_modified_date":"2016-03-02T08:54:32+11:00","description":"modified
+        - demolition of an existing dwelling and construction retirement village comprising
+        of twenty nine (29) self-care strata titled single storey dwellings, a community
+        room and private internal access road (lot 15, DP 270898 - 25 Arnold Crescent)","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-03-01T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Joseph","estimated_cost":"$11,485,000.00","related_apps":["https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.001.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.002.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.003.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.004.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.005.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.006.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.007.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.008.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.009.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.010.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.011.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.012.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.013.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.014.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.015.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.016.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.017.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.018.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.019.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.020.json","https://da.kiama.nsw.gov.au/atdis/1.0/010.2011.00000086.022.json"]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2011.00000086.021/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        1003719"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"1","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"58 Old Saddleback RD","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"2","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"1 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"3","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"3 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"5 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"5","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"7 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"6","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"9 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"7","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"11 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"8","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"13 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"9","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"15 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"10","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"17 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"11","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"14 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"12","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"16 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"13","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"22 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"14","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"24 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"15","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"25 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"16","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"27 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"17","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"29 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"18","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"31 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"19","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"33 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"20","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"35 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"21","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"34 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"22","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"8 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"23","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"10 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"24","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"12 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"25","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"18 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"26","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"20 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"27","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"26 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"28","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"28 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"29","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"30 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"30","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"32 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null},{"land_title_ref":{"torrens":{"lot":"31","section":null,"dpsp_id":"DP
+        270898"}},"address":{"street":"19 Arnold CR","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003882","timestamp":"2016-03-02T08:54:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003909","timestamp":"2016-03-02T10:12:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"}],"documents":[{"ref":"16/16203","title":"10.2011.86.21
+        - Public Plans -  25 Arnold Crescent -","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=Gz+BnOC95GM="}],"people":[{"name":"G
+        J Gardner Homes - Shoalhaven","role":"Applicant","contact":"4422 9400"},{"name":"Kiama
+        Municipal Council","role":"Principal Certifying Authority","contact":"4232
+        0444"}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":10,"pagination":{"previous":3,"next":5,"current":4,"per_page":10,"count":44,"pages":5}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:29 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:51:38 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[{"application":{"info":{"dat_id":"010.2016.00000024.001","development_type":"Subdivision
+        Only","application_type":"DA","last_modified_date":"2016-02-29T14:37:27+11:00","description":"attached
+        dual occupancy and two (2) lot torrens title subdivision","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-22T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$688,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000024.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"19","section":null,"dpsp_id":"DP
+        1206612"}},"address":{"street":"17 Northpoint PL","suburb":"BOMBO","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003045","timestamp":"2016-02-24T15:52:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003125","timestamp":"2016-02-25T10:58:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1003127","timestamp":"2016-02-25T10:59:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003128","timestamp":"2016-02-25T10:59:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"},{"id":"1003129","timestamp":"2016-02-25T10:59:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[{"ref":"16/14215","title":"10.2016.24.1
+        - Public Plans -  17 Northpoint Place Bombo - Craig White Building Design","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=+HByH3JiO3k="}],"people":[{"name":"Craig
+        White Building Design","role":"Applicant","contact":"4421 5796"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000023.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-02-29T14:37:09+11:00","description":"inground
+        swimming pool & removal of two (2) sheoak trees","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-22T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Gregory
+        Herbert","estimated_cost":"$19,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000023.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"C","section":null,"dpsp_id":"DP
+        156993"}},"address":{"street":"25 Campbell ST","suburb":"GERRINGONG","state":"NSW","postcode":"2534"},"geometry":null}],"events":[{"id":"1003042","timestamp":"2016-02-24T15:40:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003141","timestamp":"2016-02-25T11:23:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1003142","timestamp":"2016-02-25T11:24:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003143","timestamp":"2016-02-25T11:24:00+11:00","description":"Landscape
+        Officer","event_type":"TO","status":"COMP"}],"documents":[{"ref":"16/13899","title":"10.2016.23.1
+        - Public Plan -  25 Campbell Street Gerringong","document_url":"https://da.kiama.nsw.gov.au/atdis/1.0/Document/Download?key=nv39HYyFeyg="}],"people":[{"name":"Narellan
+        Pools","role":"Applicant","contact":"4262 2211"},{"name":"Owner to Appoint","role":"Principal
+        Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}},{"application":{"info":{"dat_id":"010.2016.00000027.001","development_type":"Residential
+        - Alterations & Additions","application_type":"DA","last_modified_date":"2016-02-24T16:50:26+11:00","description":"conversion
+        of existing lower floor of dwelling to secondary dwelling and addition of
+        a first floor deck","authority":{"ref":"https://da.kiama.nsw.gov.au/atdis/1.0","name":"Kiama
+        Municipal Council"},"lodgement_date":"2016-02-23T00:00:00+11:00","determination_date":null,"determination_type":"Pending","status":"In
+        Progress","notification_start_date":null,"notification_end_date":null,"officer":"Dialina
+        Day","estimated_cost":"$45,000.00","related_apps":[]},"reference":{"more_info_url":"https://da.kiama.nsw.gov.au/Application/ApplicationDetails/010.2016.00000027.001/","comments_url":null},"locations":[{"land_title_ref":{"torrens":{"lot":"4","section":null,"dpsp_id":"DP
+        156317"}},"address":{"street":"136A Shoalhaven ST","suburb":"KIAMA","state":"NSW","postcode":"2533"},"geometry":null}],"events":[{"id":"1003070","timestamp":"2016-02-24T16:50:00+11:00","description":"Preliminary
+        Assessment","event_type":"INIT","status":"COMP"},{"id":"1003114","timestamp":"2016-02-25T10:07:00+11:00","description":"Neighbour
+        Notifications Sent","event_type":"NEIG","status":"NSEN"},{"id":"1003115","timestamp":"2016-02-25T10:08:00+11:00","description":"INTERNAL
+        REFERRALS GENERATED","event_type":"REFI","status":"RGEN"},{"id":"1003116","timestamp":"2016-02-25T10:08:00+11:00","description":"Subdivision
+        & Dev. Engineer","event_type":"ENG","status":"COMP"}],"documents":[],"people":[{"name":"Set
+        Consultants Pty Ltd","role":"Applicant","contact":"4421 4500"},{"name":"Owner
+        to Appoint","role":"Principal Certifying Authority","contact":null}],"extended":{"software_vendor":"Civica","software_vendor_url":"http://www.civica.com.au"}}}],"count":3,"pagination":{"previous":4,"next":6,"current":5,"per_page":3,"count":43,"pages":15}}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:32 GMT
+- request:
+    method: get
+    uri: https://da.kiama.nsw.gov.au/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 22 Mar 2016 04:51:38 GMT
+      Strict-Transport-Security:
+      - max-age=157680000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"response":[],"count":0,"pagination":null}'
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:32 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ATDISPlanningAlertsFeed/valid_feed/should_not_error.yml
+++ b/spec/cassettes/ATDISPlanningAlertsFeed/valid_feed/should_not_error.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://mycouncil2.solorient.com.au/Horizon/@@horizondap_ashfield@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=76E28CEFE92D8EBB74A025C3E707F053; Path=/Horizon/; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 22 Mar 2016 04:16:43 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [], \r\n\"count\": 0, \r\n\"pagination\": {\r\n\"pages\":
+        1, \r\n\"per_page\": 20, \r\n\"count\": 0, \r\n\"current\": 1}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:16:43 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ATDISPlanningAlertsFeed/valid_feed/should_not_error_on_empty_feed.yml
+++ b/spec/cassettes/ATDISPlanningAlertsFeed/valid_feed/should_not_error_on_empty_feed.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Set-Cookie:
-      - JSESSIONID=76E28CEFE92D8EBB74A025C3E707F053; Path=/Horizon/; HttpOnly
+      - JSESSIONID=63F51A68E6078BD7C549133CC7984A6D; Path=/Horizon/; HttpOnly
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
       Content-Type:
@@ -29,11 +29,11 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Tue, 22 Mar 2016 04:16:43 GMT
+      - Tue, 22 Mar 2016 04:38:35 GMT
     body:
       encoding: UTF-8
       string: "{\r\n\"response\": [], \r\n\"count\": 0, \r\n\"pagination\": {\r\n\"pages\":
         1, \r\n\"per_page\": 20, \r\n\"count\": 0, \r\n\"current\": 1}\r\n}\r\n"
     http_version: 
-  recorded_at: Tue, 22 Mar 2016 04:16:43 GMT
+  recorded_at: Tue, 22 Mar 2016 04:38:35 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/ATDISPlanningAlertsFeed/with_a_flakey_service/should_not_error.yml
+++ b/spec/cassettes/ATDISPlanningAlertsFeed/with_a_flakey_service/should_not_error.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://myhorizon.cootamundra.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - text/html;charset=utf-8
+      Content-Length:
+      - '2316'
+      Date:
+      - Tue, 22 Mar 2016 04:48:33 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: "<html><head><title>Apache Tomcat/6.0.35 - Error report</title><style><!--H1
+        {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;}
+        H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;}
+        H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;}
+        BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;}
+        B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;}
+        P {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A
+        {color : black;}A.name {color : black;}HR {color : #525D76;}--></style> </head><body><h1>HTTP
+        Status 500 - </h1><HR size=\"1\" noshade=\"noshade\"><p><b>type</b> Exception
+        report</p><p><b>message</b> <u></u></p><p><b>description</b> <u>The server
+        encountered an internal error () that prevented it from fulfilling this request.</u></p><p><b>exception</b>
+        <pre>javax.servlet.ServletException: com.bas.connectionserver.server.D: Process
+        implementation component com.solorient.processes.ATDISStreetSelectProcess
+        is not found or has invalid format\n\tcom.bas.webapp.thin.servlets.RESTServlet.A(Unknown
+        Source)\n\tcom.bas.webapp.thin.servlets.RESTServlet.doGet(Unknown Source)\n\tjavax.servlet.http.HttpServlet.service(HttpServlet.java:617)\n\tjavax.servlet.http.HttpServlet.service(HttpServlet.java:717)\n</pre></p><p><b>root
+        cause</b> <pre>com.bas.connectionserver.server.D: Process implementation component
+        com.solorient.processes.ATDISStreetSelectProcess is not found or has invalid
+        format\n\tcom.bas.connectionserver.server.ConnectionFactory.sendMessage(Unknown
+        Source)\n\tcom.bas.webapp.common.WebAppUtils.sendMessageToExecutionEngine(Unknown
+        Source)\n\tcom.bas.webapp.common.WebAppUtils.sendMessageToExecutionEngine(Unknown
+        Source)\n\tcom.bas.webapp.thin.servlets.RESTServlet.A(Unknown Source)\n\tcom.bas.webapp.thin.servlets.RESTServlet.A(Unknown
+        Source)\n\tcom.bas.webapp.thin.servlets.RESTServlet.doGet(Unknown Source)\n\tjavax.servlet.http.HttpServlet.service(HttpServlet.java:617)\n\tjavax.servlet.http.HttpServlet.service(HttpServlet.java:717)\n</pre></p><p><b>note</b>
+        <u>The full stack trace of the root cause is available in the Apache Tomcat/6.0.35
+        logs.</u></p><HR size=\"1\" noshade=\"noshade\"><h3>Apache Tomcat/6.0.35</h3></body></html>"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:33 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ATDISPlanningAlertsFeed/with_a_flakey_service/should_not_error_half_way_through_processing.yml
+++ b/spec/cassettes/ATDISPlanningAlertsFeed/with_a_flakey_service/should_not_error_half_way_through_processing.yml
@@ -1,0 +1,679 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://mycouncil.yass.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=A3FA26B81FEF70E2B97BBACA71FAC046; Path=/Horizon/; HttpOnly
+      P3p:
+      - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 22 Mar 2016 05:18:28 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n\"response\": [ \r\n{\r\n\"application\": {\r\n\"reference\":
+        {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQk8eQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 2, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"BINALONG\", \r\n\"postcode\": \"2584\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"14 Wellington Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP818129\", \r\n\"lot\": \"1\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [148.635000, \r\n-34.672600]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\":
+        \"249818\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\",
+        \r\n\"id\": \"249825\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-21T00:00:00Z\", \r\n\"id\": \"249817\", \r\n\"event_type\": \"LDG\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Builder
+        to be Advised\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Ms W E Rowe\", \r\n\"role\":
+        \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"Residential
+        - Single new dwelling\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$260,000\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T15:33:26Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2016.00000069.001\",
+        \r\n\"description\": \"Dwelling House and Septic Tank with Absorption Trench\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR01PRABEcERBRkQeQ0ZLTRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 1, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"YASS\", \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"62 Petit Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP248285\", \r\n\"lot\": \"74\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.913000,
+        \r\n-34.852000]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"No Events\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\": \"0\",
+        \r\n\"event_type\": \"NIL\"}\r\n] \r\n, \r\n\"documents\": [], \r\n\"people\":
+        [ \r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"Ms P M O'Neill\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\":
+        \"Council`s Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass
+        Valley Council\", \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Single new dwelling\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$75,000\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T10:37:09Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2014.00000222.002\",
+        \r\n\"description\": \"Dwelling House\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQ0YeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 3, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"YASS\", \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"14 Barber Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP1076339\", \r\n\"lot\": \"25\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.922000,
+        \r\n-34.846600]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-21T00:00:00Z\", \r\n\"id\": \"249819\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-21T00:00:00Z\", \r\n\"id\":
+        \"249820\", \r\n\"event_type\": \"DIST\"}\r\n] \r\n, \r\n\"documents\": [],
+        \r\n\"people\": [ \r\n{\r\n\"name\": \"Mr M J Blyss\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"ACN 109 626 280 Pty Ltd\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\":
+        \"Mrs C L Blyss\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\":
+        \"Council`s Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass
+        Valley Council\", \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$17,235\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-21T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-21T16:03:30Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2016.00000070.001\",
+        \r\n\"description\": \"Storage Shed\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkEeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 4, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"MARCHMONT\", \r\n\"postcode\": \"2582\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"1 Buckley Road\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP270631\", \r\n\"lot\": \"36\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [148.945000, \r\n-34.892800]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"249795\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\":
+        \"249796\", \r\n\"event_type\": \"DIST\"}\r\n] \r\n, \r\n\"documents\": [],
+        \r\n\"people\": [ \r\n{\r\n\"contact\": \"Council`s Customer Information on
+        (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\":
+        \"Ms D H Hore\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$9,249\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T11:56:08Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2016.00000067.001\",
+        \r\n\"description\": \"Farm\\/Storage Shed\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQk4eQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 5, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"YASS\", \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"2B Mort Lane\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP1192707\", \r\n\"lot\": \"40\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.928000,
+        \r\n-34.844800]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"249806\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"249808\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\":
+        \"249807\", \r\n\"event_type\": \"DIST\"}\r\n] \r\n, \r\n\"documents\": [],
+        \r\n\"people\": [ \r\n{\r\n\"name\": \"Miss R J Pollack\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\":
+        \"Council`s Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass
+        Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Builder
+        to be Advised\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Single new dwelling\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$365,000\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-18T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T14:26:03Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2016.00000068.001\",
+        \r\n\"description\": \"Dwelling House\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkAeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 6, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"GUNDAROO\", \r\n\"postcode\": \"2620\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"71 Cork Street\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP758488\", \r\n\"lot\": \"14\", \r\n\"section\":
+        \"17\"}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [149.267000, \r\n-35.023500]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"249784\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"249783\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-18T00:00:00Z\", \r\n\"id\": \"249785\", \r\n\"event_type\": \"ACKM\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Certifier
+        to be Advised\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Tim Lee Architects\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Alterations & Additions\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$40,000\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-17T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-21T16:14:17Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J P Guiney\", \r\n\"dat_id\": \"005.2016.00000066.001\",
+        \r\n\"description\": \"New Sunroom and Covered Pergola\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkUeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 7, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"GUNDAROO\", \r\n\"postcode\": \"2620\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"591 Marked Tree Road\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP854257\", \r\n\"lot\": \"6\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [149.336000, \r\n-35.018600]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249715\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249709\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-15T00:00:00Z\", \r\n\"id\":
+        \"249710\", \r\n\"event_type\": \"DIST\"}\r\n] \r\n, \r\n\"documents\": [],
+        \r\n\"people\": [ \r\n{\r\n\"contact\": \"Council`s Customer Information on
+        (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\":
+        \"Mr I A Price\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Builder
+        to be Advised\", \r\n\"role\": \"Builder\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$16,740\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-15T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-15T12:21:17Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2016.00000063.001\",
+        \r\n\"description\": \"Storage Shed\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkMeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 9, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"YASS\", \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"38 Zouch Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP1074516\", \r\n\"lot\": \"4\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.896000,
+        \r\n-34.782100]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"Health & Env Officer Assess\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249800\", \r\n\"event_type\": \"HOA\"}\r\n,\r\n{\r\n\"description\":
+        \"Building Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249802\", \r\n\"event_type\": \"BOA\"}\r\n,\r\n{\r\n\"description\":
+        \"Planning Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249801\", \r\n\"event_type\": \"POA\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249729\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249726\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249727\", \r\n\"event_type\": \"DIST\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Builder
+        to be Advised\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Mrs C J Wilson\", \r\n\"role\":
+        \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Mr D L Wilson\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"Residential - Single new
+        dwelling\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$300,000\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-15T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T09:32:19Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Ms K A McGrath\", \r\n\"dat_id\": \"005.2016.00000065.001\",
+        \r\n\"description\": \"Dwelling House, Solid Fuel Heater and Onsite Sewerage
+        Management Facilit\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkIeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 8, \r\n\"version\": \"Online Application Tracking
+        Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\": \"http:\\/\\/www.solorient.com.au\",
+        \r\n\"software_vendor\": \"SolOrient Pty Ltd\", \r\n\"product\": \"Horizon
+        DA Portal - Build 3.18 Copyright 2016\"}\r\n, \r\n\"locations\": [ \r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"MURRUMBATEMAN\", \r\n\"postcode\": \"2582\", \r\n\"state\":
+        \"NSW\", \r\n\"street\": \"3 Banksia Court\"}\r\n, \r\n\"land_title_ref\":
+        {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP270008\", \r\n\"lot\": \"54\", \r\n\"section\":
+        null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\":
+        [149.002000, \r\n-34.991900]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"description\":
+        \"Planning Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249793\", \r\n\"event_type\": \"POA\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249717\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Building Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249794\", \r\n\"event_type\": \"BOA\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249718\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249720\", \r\n\"event_type\": \"ACKM\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Ms C J Bryant\", \r\n\"role\": \"Applicant\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"Residential - Other\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$5,416\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-15T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T12:01:28Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J P Guiney\", \r\n\"dat_id\": \"005.2016.00000064.001\",
+        \r\n\"description\": \"Extension of Existing Storage Shed\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR0pPRABEcERCRkEeQ0ZNTRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 14, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"YASS\", \r\n\"postcode\":
+        \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"42 Bellevale Road\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1169723\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [148.880000, \r\n-34.814400]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"YASS\", \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"1653 Yass Valley Way\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP1169723\", \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.884000,
+        \r\n-34.819700]}\r\n}\r\n,\r\n{\r\n\"address\": {\r\n\"suburb\": \"YASS\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1653
+        Yass Valley Way\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1209005\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.884000, \r\n-34.819700]}\r\n}\r\n,\r\n{\r\n\"address\":
+        {\r\n\"suburb\": \"YASS\", \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\",
+        \r\n\"street\": \"9 Bellevale Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\":
+        {\r\n\"dpsp_id\": \"DP1209005\", \r\n\"lot\": \"2\", \r\n\"section\": null}\r\n}\r\n,
+        \r\n\"geometry\": {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.884000,
+        \r\n-34.819700]}\r\n}\r\n] \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"249692\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\", \r\n\"id\":
+        \"249693\", \r\n\"event_type\": \"DIST\"}\r\n] \r\n, \r\n\"documents\": [],
+        \r\n\"people\": [ \r\n{\r\n\"name\": \"Bellevale Cattle Company Pty Ltd\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\": \"Council`s Customer
+        Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\":
+        \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\": \"Subdivision
+        Only\", \r\n\"notification_end_date\": null, \r\n\"determination_type\": \"Pending\",
+        \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Open\", \r\n\"lodgement_date\":
+        \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-21T16:18:02Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Ms K A McGrath\", \r\n\"dat_id\": \"005.2013.00000127.004\",
+        \r\n\"description\": \"Twenty Two (22) Lot Industrial Subdivision (Staged)\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR0xPRABEcERCRkUeQ0ZLTRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 13, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GOOD HOPE\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"737
+        Fifeshire Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP806955\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.777000, \r\n-34.934400]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"Distribution of DA\",
+        \r\n\"timestamp\": \"2016-03-14T00:00:00Z\", \r\n\"id\": \"249690\", \r\n\"event_type\":
+        \"DIST\"}\r\n,\r\n{\r\n\"status\": \"COMP\", \r\n\"description\": \"Lodgement
+        of Development Appli\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\", \r\n\"id\":
+        \"249689\", \r\n\"event_type\": \"LDG\"}\r\n] \r\n, \r\n\"documents\": [],
+        \r\n\"people\": [ \r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"contact\": \"Council`s Customer Information on
+        (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\":
+        \"Mr M Rolls\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Tourist\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$241,000\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T16:34:27Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2015.00000123.002\",
+        \r\n\"description\": \"Holiday Cabin (Restricted Occupation)\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkQeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 12, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"SUTTON\", \r\n\"postcode\":
+        \"2620\", \r\n\"state\": \"NSW\", \r\n\"street\": \"1 De Salis Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1204820\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [149.263000, \r\n-35.162800]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"Building Officer Assessment\",
+        \r\n\"timestamp\": \"2016-03-18T00:00:00Z\", \r\n\"id\": \"249792\", \r\n\"event_type\":
+        \"BOA\"}\r\n,\r\n{\r\n\"status\": \"COMP\", \r\n\"description\": \"Lodgement
+        of Development Appli\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\", \r\n\"id\":
+        \"249680\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\",
+        \r\n\"id\": \"249681\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249725\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"description\":
+        \"Planning Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249791\", \r\n\"event_type\": \"POA\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Ms M R Allan\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\":
+        \"Council`s Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass
+        Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Mr I R Towers\",
+        \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$12,000\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T09:43:59Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J T Knox\", \r\n\"dat_id\": \"005.2016.00000062.001\",
+        \r\n\"description\": \"Shelter Sheds\", \r\n\"determination_date\": null,
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkceQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 11, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOAMBOLO\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"601
+        Long Rail Gully Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP1165726\", \r\n\"lot\": \"5\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.943000, \r\n-34.946300]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\", \r\n\"description\":
+        \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\", \r\n\"id\":
+        \"249687\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\",
+        \r\n\"id\": \"249691\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"249686\", \r\n\"event_type\": \"LDG\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Mr J P
+        Patterson\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\": \"Builder
+        to be Advised\", \r\n\"role\": \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Mrs T
+        J Patterson\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$8,000\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-14T16:28:35Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2016.00000061.001\",
+        \r\n\"description\": \"Amenities in Existing Shed and Aerated Wastewater Treatment
+        System\", \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDRkpPRABEcERHQUQeQ0ZLTRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 10, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"YASS\", \r\n\"postcode\":
+        \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"48A Ford Street\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP734843\",
+        \r\n\"lot\": \"5\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [148.915000, \r\n-34.827900]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"249667\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"249666\", \r\n\"event_type\": \"LDG\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Ms A J
+        Privett\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Alterations & Additions\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$0\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-14T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-14T10:19:40Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2003.00000452.002\",
+        \r\n\"description\": \"Carport and Pergola\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQkYeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 18, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MURRUMBATEMAN\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"20 Rose
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP758736\", \r\n\"lot\": \"3\", \r\n\"section\": \"6\"}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [149.028000, \r\n-34.968300]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\", \r\n\"description\":
+        \"Acknowledgement Letter\", \r\n\"timestamp\": \"2016-03-15T00:00:00Z\", \r\n\"id\":
+        \"249722\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-11T00:00:00Z\",
+        \r\n\"id\": \"249651\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"249650\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Planning Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249787\", \r\n\"event_type\": \"POA\"}\r\n,\r\n{\r\n\"description\":
+        \"Health & Env Officer Assess\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249786\", \r\n\"event_type\": \"HOA\"}\r\n,\r\n{\r\n\"description\":
+        \"Building Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249788\", \r\n\"event_type\": \"BOA\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"contact\": \"Council`s Customer Information on
+        (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\":
+        \"Mrs C Robertson\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\":
+        {\r\n\"development_type\": \"Commercial \\/ retail \\/ office\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$32,392\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-18T09:57:27Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J T Knox\", \r\n\"dat_id\": \"005.2016.00000060.001\",
+        \r\n\"description\": \"Home Business and Storage Shed\", \r\n\"determination_date\":
+        null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQU8eQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 17, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"YASS RIVER\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"142
+        Corregans Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP775895\", \r\n\"lot\": \"8\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [149.112000, \r\n-34.911000]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\", \r\n\"description\":
+        \"Acknowledgement Letter\", \r\n\"timestamp\": \"2016-03-15T00:00:00Z\", \r\n\"id\":
+        \"249694\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\",
+        \r\n\"id\": \"249684\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"description\":
+        \"Building Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249790\", \r\n\"event_type\": \"BOA\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-14T00:00:00Z\", \r\n\"id\": \"249683\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"description\":
+        \"Planning Officer Assessment\", \r\n\"timestamp\": \"2016-03-18T00:00:00Z\",
+        \r\n\"id\": \"249789\", \r\n\"event_type\": \"POA\"}\r\n] \r\n, \r\n\"documents\":
+        [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"contact\": \"Council`s Customer Information on
+        (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\":
+        \"Mr M J Cater\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Other\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$48,196\", \r\n\"status\": \"Open\",
+        \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-18T11:36:56Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J T Knox\", \r\n\"dat_id\": \"005.2016.00000059.001\",
+        \r\n\"description\": \"Storage Shed\", \r\n\"determination_date\": null, \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR0xPRABEcERCQU8eQ0ZLTRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 16, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"MURRUMBATEMAN\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2 George
+        Street\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP243259\", \r\n\"lot\": \"30\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [149.012000, \r\n-34.992400]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"status\": \"APP2\", \r\n\"description\":
+        \"Determination of Application\\/C\", \r\n\"timestamp\": \"2016-03-16T00:00:00Z\",
+        \r\n\"id\": \"249737\", \r\n\"event_type\": \"DET\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"249644\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"249643\", \r\n\"event_type\": \"LDG\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Mrs H R Benton\", \r\n\"role\":
+        \"Builder\"}\r\n,\r\n{\r\n\"name\": \"Mrs H R Benton\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"name\":
+        \"Mr S T Benton\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Residential - Single new dwelling\", \r\n\"notification_end_date\": null,
+        \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$12,727\",
+        \r\n\"status\": \"Approved by Staff\", \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-17T12:48:00Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J S Mannweiler\", \r\n\"dat_id\": \"005.2015.00000159.002\",
+        \r\n\"description\": \"Alterations and Additions to Existing Dwelling House\",
+        \r\n\"determination_date\": \"2016-03-16T00:00:00Z\", \r\n\"application_type\":
+        \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\": {\r\n\"reference\": {\r\n\"more_info_url\":
+        \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR0xPRABEcERBQEIeQ0ZLTRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 15, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"JEIR\", \r\n\"postcode\":
+        \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"2936 Dog Trap Road\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1187670\",
+        \r\n\"lot\": \"4\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [148.942000, \r\n-35.081900]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\", \r\n\"description\": \"Distribution
+        of DA\", \r\n\"timestamp\": \"2016-03-11T00:00:00Z\", \r\n\"id\": \"249634\",
+        \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\": \"COMP\", \r\n\"description\":
+        \"Engineering Officer Assessment\", \r\n\"timestamp\": \"2016-03-14T00:00:00Z\",
+        \r\n\"id\": \"249674\", \r\n\"event_type\": \"EOA\"}\r\n,\r\n{\r\n\"status\":
+        \"APP2\", \r\n\"description\": \"Determination of Application\\/C\", \r\n\"timestamp\":
+        \"2016-03-15T00:00:00Z\", \r\n\"id\": \"249695\", \r\n\"event_type\": \"DET\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-11T00:00:00Z\", \r\n\"id\": \"249633\", \r\n\"event_type\": \"LDG\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Kova Engineering and Design
+        Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Industrial\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Approved by
+        Staff\", \r\n\"lodgement_date\": \"2016-03-11T00:00:00Z\", \r\n\"last_modified_date\":
+        \"2016-03-16T11:03:47Z\", \r\n\"authority\": {\r\n\"name\": \"Yass Valley
+        Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Ms K A McGrath\", \r\n\"dat_id\": \"005.2015.00000244.002\",
+        \r\n\"description\": \"Hard Rock Quarry\", \r\n\"determination_date\": \"2016-03-16T00:00:00Z\",
+        \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQU4eQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 20, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"GOOD HOPE\",
+        \r\n\"postcode\": \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"737
+        Fifeshire Road\"}\r\n, \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\":
+        \"DP806955\", \r\n\"lot\": \"3\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\":
+        {\r\n\"type\": \"Point\", \r\n\"coordinates\": [148.777000, \r\n-34.934400]}\r\n}\r\n]
+        \r\n, \r\n\"events\": [ \r\n{\r\n\"description\": \"Planning Officer Assessment\",
+        \r\n\"timestamp\": \"2016-03-17T00:00:00Z\", \r\n\"id\": \"249759\", \r\n\"event_type\":
+        \"POA\"}\r\n,\r\n{\r\n\"description\": \"Building Officer Assessment\", \r\n\"timestamp\":
+        \"2016-03-17T00:00:00Z\", \r\n\"id\": \"249760\", \r\n\"event_type\": \"BOA\"}\r\n,\r\n{\r\n\"description\":
+        \"Bushfire Assessment for Dev A\", \r\n\"timestamp\": \"2016-03-17T00:00:00Z\",
+        \r\n\"id\": \"249758\", \r\n\"event_type\": \"BFA\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"249616\", \r\n\"event_type\": \"ACKM\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Lodgement of Development Appli\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"249613\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"249614\", \r\n\"event_type\": \"DIST\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Mr J Rolls\",
+        \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\": \"Council`s Customer
+        Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\", \r\n\"role\":
+        \"PCA\"}\r\n,\r\n{\r\n\"name\": \"Builder to be Advised\", \r\n\"role\": \"Builder\"}\r\n]
+        \r\n, \r\n\"info\": {\r\n\"development_type\": \"Tourist\", \r\n\"notification_end_date\":
+        null, \r\n\"determination_type\": \"Pending\", \r\n\"estimated_cost\": \"$180,000\",
+        \r\n\"status\": \"Open\", \r\n\"lodgement_date\": \"2016-03-10T00:00:00Z\",
+        \r\n\"last_modified_date\": \"2016-03-17T11:31:41Z\", \r\n\"authority\": {\r\n\"name\":
+        \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr J P Guiney\", \r\n\"dat_id\": \"005.2016.00000058.001\",
+        \r\n\"description\": \"Holiday Cabin (Restricted Occupation) - Unit 10\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n,\r\n{\r\n\"application\":
+        {\r\n\"reference\": {\r\n\"more_info_url\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon\\/logonGuest.aw?e=FxkUAB1eSSgbAR0MXx0SGBFSVh0yBwc3GV0eFxcFSUMAIQYHJARfEBMKEiNZACg9HR0CHCUfHBY1QAQsHRAVAlkcGFUPEUcrNBURWDdAAxoQAhVEHS8aNxUCUVUSGBUrWRB9RENBWAJDR09PRABEcERDQUEeQ0ZITRpVAx8AEhY%3D\"}\r\n,
+        \r\n\"extended\": {\r\n\"sid\": 19, \r\n\"version\": \"Online Application
+        Tracking Data Interchange Specification 1.02 \", \r\n\"software_vendor_url\":
+        \"http:\\/\\/www.solorient.com.au\", \r\n\"software_vendor\": \"SolOrient
+        Pty Ltd\", \r\n\"product\": \"Horizon DA Portal - Build 3.18 Copyright 2016\"}\r\n,
+        \r\n\"locations\": [ \r\n{\r\n\"address\": {\r\n\"suburb\": \"BOOKHAM\", \r\n\"postcode\":
+        \"2582\", \r\n\"state\": \"NSW\", \r\n\"street\": \"134 Paynes Road\"}\r\n,
+        \r\n\"land_title_ref\": {\r\n\"torrens\": {\r\n\"dpsp_id\": \"DP1205646\",
+        \r\n\"lot\": \"1\", \r\n\"section\": null}\r\n}\r\n, \r\n\"geometry\": {\r\n\"type\":
+        \"Point\", \r\n\"coordinates\": [148.696000, \r\n-34.813800]}\r\n}\r\n] \r\n,
+        \r\n\"events\": [ \r\n{\r\n\"status\": \"COMP\", \r\n\"description\": \"Lodgement
+        of Development Appli\", \r\n\"timestamp\": \"2016-03-10T00:00:00Z\", \r\n\"id\":
+        \"249608\", \r\n\"event_type\": \"LDG\"}\r\n,\r\n{\r\n\"status\": \"COMP\",
+        \r\n\"description\": \"Distribution of DA\", \r\n\"timestamp\": \"2016-03-10T00:00:00Z\",
+        \r\n\"id\": \"249609\", \r\n\"event_type\": \"DIST\"}\r\n,\r\n{\r\n\"status\":
+        \"COMP\", \r\n\"description\": \"Acknowledgement Letter\", \r\n\"timestamp\":
+        \"2016-03-10T00:00:00Z\", \r\n\"id\": \"249612\", \r\n\"event_type\": \"ACKM\"}\r\n]
+        \r\n, \r\n\"documents\": [], \r\n\"people\": [ \r\n{\r\n\"name\": \"Bogo Operations
+        Pty Ltd\", \r\n\"role\": \"Applicant\"}\r\n,\r\n{\r\n\"contact\": \"Council`s
+        Customer Information on (02) 6226 1477\", \r\n\"name\": \"Yass Valley Council\",
+        \r\n\"role\": \"PCA\"}\r\n] \r\n, \r\n\"info\": {\r\n\"development_type\":
+        \"Industrial\", \r\n\"notification_end_date\": null, \r\n\"determination_type\":
+        \"Pending\", \r\n\"estimated_cost\": \"$0\", \r\n\"status\": \"Open\", \r\n\"lodgement_date\":
+        \"2016-03-10T00:00:00Z\", \r\n\"last_modified_date\": \"2016-03-14T15:55:52Z\",
+        \r\n\"authority\": {\r\n\"name\": \"Yass Valley Council\", \r\n\"ref\": \"http:\\/\\/mycouncil.yass.nsw.gov.au\\/Horizon%40%40horizondap%40%40\\/atdis\\/1.0\"}\r\n,
+        \r\n\"officer\": \"Mr M M Rubbani\", \r\n\"dat_id\": \"005.2016.00000057.001\",
+        \r\n\"description\": \"Extension of Quarry Life for Approximately 30 Years\",
+        \r\n\"determination_date\": null, \r\n\"application_type\": \"DA\"}\r\n}\r\n}\r\n]
+        \r\n, \r\n\"count\": 20, \r\n\"pagination\": {\r\n\"pages\": 3, \r\n\"per_page\":
+        20, \r\n\"next\": 2, \r\n\"count\": 46, \r\n\"current\": 1}\r\n}\r\n"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 05:18:23 GMT
+- request:
+    method: get
+    uri: http://mycouncil.yass.nsw.gov.au/Horizon/@@horizondap@@/atdis/1.0//applications.json?lodgement_date_end=2016-03-22&lodgement_date_start=2016-02-21&page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - text/html;charset=utf-8
+      Content-Length:
+      - '43'
+      Date:
+      - Tue, 22 Mar 2016 04:48:33 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: "Faked error response, take that, rspec-mock"
+    http_version: 
+  recorded_at: Tue, 22 Mar 2016 04:48:33 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
This set of refactoring treats the ATDISPlanningAlertsFeed more like an application than a library - think what Mechanize is to HTTP Client.

I've added basic specs and refactored the order in which things are processed (better application of SRP) but at a cost of being potentially more fragile.

Features added:
- Rudimentary test coverage
- Logging is a bit more configurable
- A feed can be tagged as flakey via the options, so that HTTP 500 errors in the middle of the feed are logged instead of raised.

Bugs worked around or fixed:
- https://github.com/openaustralia/atdis/issues/40
- Fixes #3 - Malformed navigation 
